### PR TITLE
chore: migrate doc URLs from aisa.mintlify.app to docs.aisa.one

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See existing skills for reference.
 
 - 🦞 [OpenClaw](https://openclaw.ai) - The autonomous agent framework
 - ⚡ [AIsa](https://aisa.one) - Unified API backend
-- 📖 [Documentation](https://aisa.mintlify.app) - API reference
+- 📖 [Documentation](https://docs.aisa.one) - API reference
 
 ---
 

--- a/aisa/README.md
+++ b/aisa/README.md
@@ -230,7 +230,7 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 - [SKILL.md](SKILL.md) - OpenClaw skill specification
 - [API Reference](references/api-reference.md) - Complete endpoint documentation
-- [AIsa Docs](https://aisa.mintlify.app) - Full API documentation
+- [AIsa Docs](https://docs.aisa.one) - Full API documentation
 
 ---
 
@@ -256,7 +256,7 @@ Apache 2.0 License - see [LICENSE](../LICENSE) for details.
 
 - 🦞 [OpenClaw](https://openclaw.ai) - The autonomous agent framework
 - ⚡ [AIsa](https://aisa.one) - Unified API backend
-- 📖 [API Docs](https://aisa.mintlify.app) - Full documentation
+- 📖 [API Docs](https://docs.aisa.one) - Full documentation
 
 ---
 

--- a/aisa/references/api-reference.md
+++ b/aisa/references/api-reference.md
@@ -2,7 +2,7 @@
 
 **Powered by AIsa**
 
-Complete API documentation based on [aisa.mintlify.app](https://aisa.mintlify.app/api-reference/introduction).
+Complete API documentation based on [docs.aisa.one](https://docs.aisa.one/reference/introduction).
 
 ## Base URL
 
@@ -194,5 +194,5 @@ OpenAI-compatible chat completions.
 ## Full Documentation
 
 For complete API documentation including all endpoints:
-- [AIsa API Reference](https://aisa.mintlify.app/api-reference/introduction)
-- [Documentation Index](https://aisa.mintlify.app/llms.txt)
+- [AIsa API Reference](https://docs.aisa.one/reference/introduction)
+- [Documentation Index](https://docs.aisa.one/llms.txt)

--- a/aisa/references/api-reference.md
+++ b/aisa/references/api-reference.md
@@ -2,7 +2,7 @@
 
 **Powered by AIsa**
 
-Complete API documentation based on [docs.aisa.one](https://docs.aisa.one/reference/introduction).
+Complete API documentation based on [docs.aisa.one](https://docs.aisa.one/reference/).
 
 ## Base URL
 
@@ -194,5 +194,5 @@ OpenAI-compatible chat completions.
 ## Full Documentation
 
 For complete API documentation including all endpoints:
-- [AIsa API Reference](https://docs.aisa.one/reference/introduction)
+- [AIsa API Reference](https://docs.aisa.one/reference/)
 - [Documentation Index](https://docs.aisa.one/llms.txt)

--- a/cn-llm/SKILL.md
+++ b/cn-llm/SKILL.md
@@ -382,4 +382,4 @@ Common error codes:
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.

--- a/cn-llm/SKILL.md
+++ b/cn-llm/SKILL.md
@@ -382,4 +382,4 @@ Common error codes:
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.

--- a/llm-router/SKILL.md
+++ b/llm-router/SKILL.md
@@ -465,4 +465,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.

--- a/llm-router/SKILL.md
+++ b/llm-router/SKILL.md
@@ -465,4 +465,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.

--- a/market/SKILL.md
+++ b/market/SKILL.md
@@ -344,4 +344,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.

--- a/market/SKILL.md
+++ b/market/SKILL.md
@@ -344,4 +344,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.

--- a/media-gen/README.md
+++ b/media-gen/README.md
@@ -5,7 +5,7 @@
 - **Gemini 图片**：`gemini-3-pro-image-preview`（`/v1/models/{model}:generateContent`）
 - **Wan 2.6 视频**：`wan2.6-t2v`（`/apis/v1/services/aigc/...` 异步任务 + 轮询）
 
-相关 API 文档索引：[`https://aisa.mintlify.app/api-reference/introduction`](https://aisa.mintlify.app/api-reference/introduction)
+相关 API 文档索引：[`https://docs.aisa.one/reference/introduction`](https://docs.aisa.one/reference/introduction)
 
 ### 快速开始
 

--- a/media-gen/README.md
+++ b/media-gen/README.md
@@ -5,7 +5,7 @@
 - **Gemini 图片**：`gemini-3-pro-image-preview`（`/v1/models/{model}:generateContent`）
 - **Wan 2.6 视频**：`wan2.6-t2v`（`/apis/v1/services/aigc/...` 异步任务 + 轮询）
 
-相关 API 文档索引：[`https://docs.aisa.one/reference/introduction`](https://docs.aisa.one/reference/introduction)
+相关 API 文档索引：[`https://docs.aisa.one/reference/`](https://docs.aisa.one/reference/)
 
 ### 快速开始
 

--- a/media-gen/SKILL.md
+++ b/media-gen/SKILL.md
@@ -12,7 +12,7 @@ metadata: {"openclaw":{"emoji":"🎬","requires":{"bins":["python3","curl"],"env
 - **图片**：`gemini-3-pro-image-preview`（Gemini GenerateContent）
 - **视频**：`wan2.6-t2v`（通义万相 / Qwen Wan 2.6，异步任务）
 
-API 文档索引见 [AIsa API Reference](https://aisa.mintlify.app/api-reference/introduction)（可从 `https://aisa.mintlify.app/llms.txt` 找到所有页面）。
+API 文档索引见 [AIsa API Reference](https://docs.aisa.one/reference/introduction)（可从 `https://docs.aisa.one/llms.txt` 找到所有页面）。
 
 ## 🔥 你可以做什么
 
@@ -41,7 +41,7 @@ export AISA_API_KEY="your-key"
 - Base URL: `https://api.aisa.one/v1`
 - `POST /models/{model}:generateContent`
 
-文档：`google-gemini-chat`（GenerateContent）见 `https://aisa.mintlify.app/api-reference/chat/chat-api/google-gemini-chat.md`。
+文档：`google-gemini-chat`（GenerateContent）见 `https://docs.aisa.one/reference/chat/chat-api/google-gemini-chat.md`。
 
 ### curl 示例（返回 inline_data 时为图片）
 
@@ -68,7 +68,7 @@ curl -X POST "https://api.aisa.one/v1/models/gemini-3-pro-image-preview:generate
 - `POST /services/aigc/video-generation/video-synthesis`
 - Header：`X-DashScope-Async: enable`（必填，异步）
 
-文档：`video-generation` 见 `https://aisa.mintlify.app/api-reference/aliyun/video/video-generation.md`。
+文档：`video-generation` 见 `https://docs.aisa.one/reference/aliyun/video/video-generation.md`。
 
 ```bash
 curl -X POST "https://api.aisa.one/apis/v1/services/aigc/video-generation/video-synthesis" \
@@ -94,7 +94,7 @@ curl -X POST "https://api.aisa.one/apis/v1/services/aigc/video-generation/video-
 
 - `GET /services/aigc/tasks?task_id=...`
 
-文档：`task` 见 `https://aisa.mintlify.app/api-reference/aliyun/video/task.md`。
+文档：`task` 见 `https://docs.aisa.one/reference/aliyun/video/task.md`。
 
 ```bash
 curl "https://api.aisa.one/apis/v1/services/aigc/tasks?task_id=YOUR_TASK_ID" \

--- a/media-gen/SKILL.md
+++ b/media-gen/SKILL.md
@@ -12,7 +12,7 @@ metadata: {"openclaw":{"emoji":"🎬","requires":{"bins":["python3","curl"],"env
 - **图片**：`gemini-3-pro-image-preview`（Gemini GenerateContent）
 - **视频**：`wan2.6-t2v`（通义万相 / Qwen Wan 2.6，异步任务）
 
-API 文档索引见 [AIsa API Reference](https://docs.aisa.one/reference/introduction)（可从 `https://docs.aisa.one/llms.txt` 找到所有页面）。
+API 文档索引见 [AIsa API Reference](https://docs.aisa.one/reference/)（可从 `https://docs.aisa.one/llms.txt` 找到所有页面）。
 
 ## 🔥 你可以做什么
 
@@ -41,7 +41,7 @@ export AISA_API_KEY="your-key"
 - Base URL: `https://api.aisa.one/v1`
 - `POST /models/{model}:generateContent`
 
-文档：`google-gemini-chat`（GenerateContent）见 `https://docs.aisa.one/reference/chat/chat-api/google-gemini-chat.md`。
+文档：`google-gemini-chat`（GenerateContent）见 `https://docs.aisa.one/reference/generatecontent`。
 
 ### curl 示例（返回 inline_data 时为图片）
 
@@ -68,7 +68,7 @@ curl -X POST "https://api.aisa.one/v1/models/gemini-3-pro-image-preview:generate
 - `POST /services/aigc/video-generation/video-synthesis`
 - Header：`X-DashScope-Async: enable`（必填，异步）
 
-文档：`video-generation` 见 `https://docs.aisa.one/reference/aliyun/video/video-generation.md`。
+文档：`video-generation` 见 `https://docs.aisa.one/reference/post_services-aigc-video-generation-video-synthesis`。
 
 ```bash
 curl -X POST "https://api.aisa.one/apis/v1/services/aigc/video-generation/video-synthesis" \
@@ -94,7 +94,7 @@ curl -X POST "https://api.aisa.one/apis/v1/services/aigc/video-generation/video-
 
 - `GET /services/aigc/tasks?task_id=...`
 
-文档：`task` 见 `https://docs.aisa.one/reference/aliyun/video/task.md`。
+文档：`task` 见 `https://docs.aisa.one/reference/get_services-aigc-tasks`。
 
 ```bash
 curl "https://api.aisa.one/apis/v1/services/aigc/tasks?task_id=YOUR_TASK_ID" \

--- a/search/SKILL.md
+++ b/search/SKILL.md
@@ -341,9 +341,9 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
 
 ## Resources
 
 - [AIsa Verity](https://github.com/AIsa-team/verity) - Reference implementation of confidence-scored search agent
-- [AIsa Documentation](https://aisa.mintlify.app) - Complete API documentation
+- [AIsa Documentation](https://docs.aisa.one) - Complete API documentation

--- a/search/SKILL.md
+++ b/search/SKILL.md
@@ -341,7 +341,7 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.
 
 ## Resources
 

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -33,4 +33,4 @@ Sign up at [aisa.one](https://aisa.one)
 ## Links
 
 - [ClawHub](https://www.clawhub.com/aisa-one/openclaw-twitter)
-- [API Reference](https://aisa.mintlify.app/api-reference/introduction)
+- [API Reference](https://docs.aisa.one/reference/introduction)

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -33,4 +33,4 @@ Sign up at [aisa.one](https://aisa.one)
 ## Links
 
 - [ClawHub](https://www.clawhub.com/aisa-one/openclaw-twitter)
-- [API Reference](https://docs.aisa.one/reference/introduction)
+- [API Reference](https://docs.aisa.one/reference/)

--- a/twitter/SKILL.md
+++ b/twitter/SKILL.md
@@ -182,4 +182,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.

--- a/twitter/SKILL.md
+++ b/twitter/SKILL.md
@@ -182,4 +182,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.

--- a/youtube/SKILL.md
+++ b/youtube/SKILL.md
@@ -267,4 +267,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://aisa.mintlify.app/api-reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.

--- a/youtube/SKILL.md
+++ b/youtube/SKILL.md
@@ -267,4 +267,4 @@ Every response includes `usage.cost` and `usage.credits_remaining`.
 
 ## Full API Reference
 
-See [API Reference](https://docs.aisa.one/reference/introduction) for complete endpoint documentation.
+See [API Reference](https://docs.aisa.one/reference/) for complete endpoint documentation.


### PR DESCRIPTION
## Summary

- Update all documentation links across 12 files to use the new `docs.aisa.one` domain instead of the old `aisa.mintlify.app`
- Affects: README.md, aisa/, cn-llm/, llm-router/, market/, media-gen/, search/, twitter/, youtube/

## Test plan

- [x] All links updated consistently (`aisa.mintlify.app` → `docs.aisa.one`, `/api-reference/` → `/reference/`)
- [ ] Verify `docs.aisa.one` URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)