### PR TITLE
Update prediction-market skill: add end-to-end examples, expand sports coverage

### DIFF
--- a/prediction-market/scripts/prediction_market_client.py
+++ b/prediction-market/scripts/prediction_market_client.py
@@ -291,7 +291,7 @@ class PredictionMarketClient:
     def sports_by_date(self, sport: str, date: str) -> Dict[str, Any]:
         """Find matching sports markets across platforms by sport and date (YYYY-MM-DD).
 
-        Supported sports: nba, nfl, mlb, nhl, soccer, tennis.
+        Supported sports: nfl, mlb, cfb, nba, nhl, cbb, pga, tennis.
         """
         return self._request(f"/matching-markets/sports/{sport}", params={"date": date})
 
@@ -461,7 +461,7 @@ Examples:
     sp_match_group.add_argument("--kalshi-ticker", nargs="+", help="Kalshi event ticker(s)")
 
     sp_date = sp_sub.add_parser("by-date", help="Find matching sports markets by date")
-    sp_date.add_argument("sport", choices=["nba", "nfl", "mlb", "nhl", "soccer", "tennis"])
+    sp_date.add_argument("sport", choices=["nfl", "mlb", "cfb", "nba", "nhl", "cbb", "pga", "tennis"])
     sp_date.add_argument("--date", required=True, help="Date in YYYY-MM-DD format")
 
     args = parser.parse_args()

--- a/prediction-market/skill.md
+++ b/prediction-market/skill.md
@@ -2,10 +2,10 @@
 name: Prediction Market Data
 description: "Prediction markets data - Polymarket, Kalshi markets, prices, positions, and trades"
 homepage: https://openclaw.ai
-metadata: {"openclaw":{"emoji":"📈","requires":{"bins":["curl","python3"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY"}}
+metadata: {"openclaw":{"emoji":"ð","requires":{"bins":["curl","python3"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY"}}
 ---
 
-# Cross-Platform Prediction Market Data 📈
+# Cross-Platform Prediction Market Data ð
 
 **Prediction markets data access for autonomous agents. Powered by AIsa.**
 
@@ -48,9 +48,83 @@ export AISA_API_KEY="your-key"
 
 Most endpoints require an ID that comes from the `/markets` response. Always query markets first, then pass the relevant ID to downstream endpoints.
 
-1. **Polymarket `token_id`** — Query `/polymarket/markets`, find `side_a.id` or `side_b.id` in the response, then pass it to `/polymarket/market-price/{token_id}`.
-2. **Polymarket `condition_id`** — Query `/polymarket/markets`, find `condition_id` in the response, then pass it to `/polymarket/candlesticks/{condition_id}`.
-3. **Kalshi `market_ticker`** — Query `/kalshi/markets`, find `market_ticker` in the response, then pass it to `/kalshi/market-price/{market_ticker}`.
+1. **Polymarket `token_id`** â Query `/polymarket/markets`, find `side_a.id` or `side_b.id` in the response, then pass it to `/polymarket/market-price/{token_id}`.
+2. **Polymarket `condition_id`** â Query `/polymarket/markets`, find `condition_id` in the response, then pass it to `/polymarket/candlesticks/{condition_id}`.
+3. **Kalshi `market_ticker`** â Query `/kalshi/markets`, find `market_ticker` in the response, then pass it to `/kalshi/market-price/{market_ticker}`.
+
+## End-to-End Examples
+
+### Get the current price of a Polymarket market
+
+Prices require a `token_id`, which comes from the `/markets` response. Always query markets first.
+
+**Step 1 â Find a market and extract the token_id:**
+
+```bash
+# Search for open election markets and grab a token_id
+python prediction_market_client.py polymarket markets --search "election" --status open --limit 5
+```
+
+The response includes a `side_a.id` and `side_b.id` for each market â these are the token IDs for the Yes and No sides respectively:
+
+```json
+{
+  "markets": [
+    {
+      "title": "Will Trump nationalize elections?",
+      "market_slug": "will-trump-nationalize-elections",
+      "condition_id": "0xe6522d64f35a6843ebdbccab2e3d4a1385350be6d40a3de766330e207b71a8ba",
+      "side_a": {
+        "id": "44482086252598348208660011972852804909957485351743405768768577675743702971026",
+        "label": "Yes"
+      },
+      "side_b": {
+        "id": "68987475491741167427045844503509447338405188188495224371188027929166363674438",
+        "label": "No"
+      }
+    }
+  ]
+}
+```
+
+**Step 2 â Fetch the current price using the token_id:**
+
+```bash
+# Use side_a.id (Yes) or side_b.id (No) from Step 1
+python prediction_market_client.py polymarket price 44482086252598348208660011972852804909957485351743405768768577675743702971026
+```
+
+The price is a decimal between 0 and 1 representing the probability (e.g. `0.20` = 20% chance of Yes).
+
+---
+
+### Get the current price of a Kalshi market
+
+**Step 1 â Find a market and extract the market_ticker:**
+
+```bash
+python prediction_market_client.py kalshi markets --search "fed rate" --status open --limit 5
+```
+
+```json
+{
+  "markets": [
+    {
+      "title": "Will the federal funds rate be above 3.75% after the Mar 2026 meeting?",
+      "market_ticker": "KXFED-26MAR-T3.75",
+      "last_price": 6
+    }
+  ]
+}
+```
+
+**Step 2 â Fetch the price using the market_ticker:**
+
+```bash
+python prediction_market_client.py kalshi price KXFED-26MAR-T3.75
+```
+
+---
 
 ## Core Capabilities
 
@@ -67,8 +141,8 @@ curl -X GET "https://api.aisa.one/apis/v1/polymarket/markets?search=election&sta
 #### Market Price
 
 ```bash
-# Fetch the current market price for a market by token_id
-# token_id comes from side_a.id or side_b.id in /polymarket/markets response
+# Step 1: query /polymarket/markets to get a token_id from side_a.id or side_b.id
+# Step 2: pass that token_id here to get the current price
 curl -X GET "https://api.aisa.one/apis/v1/polymarket/market-price/{token_id}" \
   -H "Authorization: Bearer $AISA_API_KEY"
 ```
@@ -181,10 +255,25 @@ curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports" \
 #### Sports Markets by Date
 
 ```bash
-# Find equivalent markets across platforms for sports events by date
-curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports/nba?date=2024-03-01" \
+# Find equivalent markets across platforms for a sport on a given date
+# sport options: nfl, mlb, cfb, nba, nhl, cbb, pga, tennis
+# date format: YYYY-MM-DD
+curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports/nba?date=2025-08-16" \
   -H "Authorization: Bearer $AISA_API_KEY"
 ```
+
+Sport abbreviations:
+
+| Abbreviation | Sport |
+|---|---|
+| `nfl` | Football |
+| `mlb` | Baseball |
+| `cfb` | College Football |
+| `nba` | Basketball |
+| `nhl` | Hockey |
+| `cbb` | College Basketball |
+| `pga` | Golf |
+| `tennis` | Tennis |
 
 ## API Endpoints Reference
 
@@ -216,7 +305,7 @@ curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports/nba?date=2024-
 | Endpoint | Description | Key Params |
 |----------|-------------|------------|
 | `/matching-markets/sports` | Find matching sports markets | `polymarket_market_slug` or `kalshi_event_ticker` |
-| `/matching-markets/sports/{sport}` | Find sports markets by date | `sport`, `date` |
+| `/matching-markets/sports/{sport}` | Find sports markets by date | `sport` (nfl\|mlb\|cfb\|nba\|nhl\|cbb\|pga\|tennis), `date` (YYYY-MM-DD) |
 
 ## Response Schemas
 


### PR DESCRIPTION
## Changes

### `skill.md`
- **New "End-to-End Examples" section** — Added detailed step-by-step walkthroughs for getting Polymarket and Kalshi prices, including sample JSON responses showing how to extract `token_id` and `market_ticker`
- **Added sport abbreviations table** — Reference table mapping abbreviations (nfl, mlb, cfb, nba, nhl, cbb, pga, tennis) to sport names
- **Updated sports endpoint reference** — Added explicit sport options and date format to the cross-platform endpoints table
- **Improved Market Price comments** — Changed to explicit two-step instructions (query markets first, then pass ID)
- **Updated sports date example** — Changed from `2024-03-01` to `2025-08-16`

### `prediction_market_client.py`
- **Updated supported sports list** — Added `cfb` (College Football), `cbb` (College Basketball), `pga` (Golf); removed `soccer`
