### PR TITLE
Update prediction-market-arbitrage skill: expand sports coverage, add sport table

### DIFF
--- a/prediction-market-arbitrage/script/arbitrage_finder.py
+++ b/prediction-market-arbitrage/script/arbitrage_finder.py
@@ -546,7 +546,7 @@ Examples:
     )
     scan_parser.add_argument(
         "sport",
-        choices=["nba", "nfl", "mlb", "nhl", "soccer", "tennis"],
+        choices=["nfl", "mlb", "cfb", "nba", "nhl", "cbb", "pga", "tennis"],
         help="Sport to scan",
     )
     scan_parser.add_argument("--date", required=True, help="Date in YYYY-MM-DD format")

--- a/prediction-market-arbitrage/script/prediction_market_client.py
+++ b/prediction-market-arbitrage/script/prediction_market_client.py
@@ -291,7 +291,7 @@ class PredictionMarketClient:
     def sports_by_date(self, sport: str, date: str) -> Dict[str, Any]:
         """Find matching sports markets across platforms by sport and date (YYYY-MM-DD).
 
-        Supported sports: nba, nfl, mlb, nhl, soccer, tennis.
+        Supported sports: nfl, mlb, cfb, nba, nhl, cbb, pga, tennis.
         """
         return self._request(f"/matching-markets/sports/{sport}", params={"date": date})
 
@@ -461,7 +461,7 @@ Examples:
     sp_match_group.add_argument("--kalshi-ticker", nargs="+", help="Kalshi event ticker(s)")
 
     sp_date = sp_sub.add_parser("by-date", help="Find matching sports markets by date")
-    sp_date.add_argument("sport", choices=["nba", "nfl", "mlb", "nhl", "soccer", "tennis"])
+    sp_date.add_argument("sport", choices=["nfl", "mlb", "cfb", "nba", "nhl", "cbb", "pga", "tennis"])
     sp_date.add_argument("--date", required=True, help="Date in YYYY-MM-DD format")
 
     args = parser.parse_args()

--- a/prediction-market-arbitrage/skill.md
+++ b/prediction-market-arbitrage/skill.md
@@ -68,7 +68,9 @@ curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports?kalshi_event_t
 
 ```bash
 # Find all matching sports markets across platforms for a specific date
-curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports/nba?date=2024-03-01" \
+# sport options: nfl, mlb, cfb, nba, nhl, cbb, pga, tennis
+# date format: YYYY-MM-DD
+curl -X GET "https://api.aisa.one/apis/v1/matching-markets/sports/nba?date=2025-08-16" \
   -H "Authorization: Bearer $AISA_API_KEY"
 ```
 
@@ -79,8 +81,8 @@ Once matching markets are found, fetch the real-time prices on both platforms to
 #### Get Polymarket Price
 
 ```bash
-# Fetch the current market price for a Polymarket token
-# token_id comes from side_a.id or side_b.id in /polymarket/markets response
+# Step 1: query /polymarket/markets to get a token_id from side_a.id or side_b.id
+# Step 2: pass that token_id here to get the current price
 curl -X GET "https://api.aisa.one/apis/v1/polymarket/market-price/{token_id}" \
   -H "Authorization: Bearer $AISA_API_KEY"
 ```
@@ -123,7 +125,20 @@ curl -X GET "https://api.aisa.one/apis/v1/kalshi/orderbooks?ticker={ticker}" \
 | Endpoint | Description | Key Params |
 |----------|-------------|------------|
 | `/matching-markets/sports` | Find matching sports markets | `polymarket_market_slug` or `kalshi_event_ticker` |
-| `/matching-markets/sports/{sport}` | Find sports markets by date | `sport`, `date` |
+| `/matching-markets/sports/{sport}` | Find sports markets by date | `sport` (nfl\|mlb\|cfb\|nba\|nhl\|cbb\|pga\|tennis), `date` (YYYY-MM-DD) |
+
+Sport abbreviations:
+
+| Abbreviation | Sport |
+|---|---|
+| `nfl` | Football |
+| `mlb` | Baseball |
+| `cfb` | College Football |
+| `nba` | Basketball |
+| `nhl` | Hockey |
+| `cbb` | College Basketball |
+| `pga` | Golf |
+| `tennis` | Tennis |
 
 ### Price & Liquidity Endpoints (GET)
 


### PR DESCRIPTION
## Changes

Applies the same updates from PR #8 (prediction-market) to the **prediction-market-arbitrage** skill.

### `script/arbitrage_finder.py`
- **Updated supported sports list** — Changed from `[nba, nfl, mlb, nhl, soccer, tennis]` to `[nfl, mlb, cfb, nba, nhl, cbb, pga, tennis]`

### `script/prediction_market_client.py`
- **Updated supported sports list** — Same change: added `cfb` (College Football), `cbb` (College Basketball), `pga` (Golf); removed `soccer`

### `skill.md`
- **Added sport abbreviations reference table** — Maps all 8 sport abbreviations to full names
- **Updated sports endpoint reference** — Added explicit sport options and date format to the cross-platform endpoints table
- **Updated sports date example** — Changed from `2024-03-01` to `2025-08-16`
- **Improved Market Price comments** — Changed to explicit two-step instructions (query markets first, then pass ID)
