### PR TITLE
Add dome-api skill

### DIFF
--- a/dome-api/SKILL.md
+++ b/dome-api/SKILL.md
@@ -1,17 +1,17 @@
 ---
-name: dome-api
-description: Interacts with the Dome API for prediction market data (Polymarket, Kalshi) and matching markets. Use when you need to fetch prediction market data, prices, or orderbook information using the AIsa proxy endpoint.
+name: prediction-market-api
+description: Interacts with the AIsa API proxy for prediction market data (Polymarket, Kalshi) and matching markets. Use when you need to fetch prediction market data, prices, or orderbook information via the AIsa API proxy.
 ---
 
-# Dome API Skill
+# Prediction Market API Skill
 
-This skill provides a Python client to interact with the Dome API, which offers comprehensive access to prediction market data across platforms like Polymarket and Kalshi.
+This skill provides a Python client to interact with the AIsa API proxy, which offers comprehensive access to prediction market data across platforms like Polymarket and Kalshi.
 
-**Important Note**: The API base URL has been configured to use the AIsa proxy endpoint: `https://api.aisa.one/apis/v1`.
+**Base URL**: `https://api.aisa.one/apis/v1`
 
 ## Capabilities
 
-The Dome API provides access to:
+The AIsa API proxy provides access to:
 1. **Polymarket Data**: Markets, Events, Trade History, Orderbooks, Activity, Market Prices, Candlesticks, Positions, Wallet Info, and PnL.
 2. **Kalshi Data**: Markets, Trade History, Market Prices, and Orderbooks.
 3. **Matching Markets**: Find equivalent markets across different prediction market platforms for sports events.
@@ -19,22 +19,20 @@ The Dome API provides access to:
 
 ## Bundled Resources
 
-- `scripts/client.py`: A comprehensive Python client class (`DomeAPIClient`) that implements all major REST endpoints of the Dome API.
+- `scripts/client.py`: A comprehensive Python client class (`PredictionMarketAPIClient`) that implements all major REST endpoints.
 
 ## Usage Instructions
 
-To use the Dome API, import the `DomeAPIClient` from the bundled script.
+To use the API, import the `PredictionMarketAPIClient` from the bundled script.
 
 ```python
 import sys
-import os
 
-# Add the scripts directory to the path so we can import the client
-sys.path.append('/home/ubuntu/skills/dome-api/scripts')
-from client import DomeAPIClient
+sys.path.append('/home/ubuntu/skills/prediction-market-api/scripts')
+from client import PredictionMarketAPIClient
 
-# Initialize the client (API key is optional for some public endpoints)
-client = DomeAPIClient(api_key="your_api_key_here")
+# Initialize the client
+client = PredictionMarketAPIClient(api_key="your_api_key_here")
 
 # Example: Get Polymarket market price
 market_price = client.get_polymarket_market_price("19701256321759583954581192053894521654935987478209343000964756587964612528044")
@@ -69,9 +67,9 @@ kalshi_markets = client.get_kalshi_markets(search="bitcoin", limit=5)
 - `get_matching_sport_by_date()`: Find equivalent sports markets by date.
 
 #### Order Router
-- `place_order()`: Place an order on Polymarket via Dome infrastructure.
+- `place_order()`: Place an order on Polymarket via the AIsa API proxy.
 
 ## Websockets
 
-Dome API also provides real-time data streaming through WebSocket connections at `wss://ws.domeapi.io/<API_KEY>`.
+Real-time data streaming is available through WebSocket connections.
 You can subscribe to orders filtered by users, condition IDs, or market slugs.

--- a/dome-api/SKILL.md
+++ b/dome-api/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: dome-api
+description: Interacts with the Dome API for prediction market data (Polymarket, Kalshi) and matching markets. Use when you need to fetch prediction market data, prices, or orderbook information using the AIsa proxy endpoint.
+---
+
+# Dome API Skill
+
+This skill provides a Python client to interact with the Dome API, which offers comprehensive access to prediction market data across platforms like Polymarket and Kalshi.
+
+**Important Note**: The API base URL has been configured to use the AIsa proxy endpoint: `https://api.aisa.one/apis/v1`.
+
+## Capabilities
+
+The Dome API provides access to:
+1. **Polymarket Data**: Markets, Events, Trade History, Orderbooks, Activity, Market Prices, Candlesticks, Positions, Wallet Info, and PnL.
+2. **Kalshi Data**: Markets, Trade History, Market Prices, and Orderbooks.
+3. **Matching Markets**: Find equivalent markets across different prediction market platforms for sports events.
+4. **Order Router**: Place orders on Polymarket with server-side execution.
+
+## Bundled Resources
+
+- `scripts/client.py`: A comprehensive Python client class (`DomeAPIClient`) that implements all major REST endpoints of the Dome API.
+
+## Usage Instructions
+
+To use the Dome API, import the `DomeAPIClient` from the bundled script.
+
+```python
+import sys
+import os
+
+# Add the scripts directory to the path so we can import the client
+sys.path.append('/home/ubuntu/skills/dome-api/scripts')
+from client import DomeAPIClient
+
+# Initialize the client (API key is optional for some public endpoints)
+client = DomeAPIClient(api_key="your_api_key_here")
+
+# Example: Get Polymarket market price
+market_price = client.get_polymarket_market_price("19701256321759583954581192053894521654935987478209343000964756587964612528044")
+print(f"Price: {market_price.get('price')}")
+
+# Example: Search for Kalshi markets
+kalshi_markets = client.get_kalshi_markets(search="bitcoin", limit=5)
+```
+
+### Key Endpoints Available in the Client
+
+#### Polymarket
+- `get_polymarket_markets()`: Find markets with various filters.
+- `get_polymarket_events()`: List events.
+- `get_polymarket_orders()`: Fetch historical trade data.
+- `get_polymarket_orderbooks()`: Fetch historical orderbook snapshots.
+- `get_polymarket_activity()`: Fetch activity data.
+- `get_polymarket_market_price()`: Get current or historical market price.
+- `get_polymarket_candlesticks()`: Fetch historical candlestick data.
+- `get_polymarket_positions()`: Fetch positions for a wallet.
+- `get_polymarket_wallet()`: Fetch wallet info.
+- `get_polymarket_wallet_pnl()`: Fetch realized PnL for a wallet.
+
+#### Kalshi
+- `get_kalshi_markets()`: Find markets.
+- `get_kalshi_trades()`: Fetch historical trade data.
+- `get_kalshi_market_price()`: Get current market price.
+- `get_kalshi_orderbooks()`: Fetch historical orderbook snapshots.
+
+#### Matching Markets
+- `get_matching_sports()`: Find equivalent sports markets.
+- `get_matching_sport_by_date()`: Find equivalent sports markets by date.
+
+#### Order Router
+- `place_order()`: Place an order on Polymarket via Dome infrastructure.
+
+## Websockets
+
+Dome API also provides real-time data streaming through WebSocket connections at `wss://ws.domeapi.io/<API_KEY>`.
+You can subscribe to orders filtered by users, condition IDs, or market slugs.

--- a/dome-api/scripts/client.py
+++ b/dome-api/scripts/client.py
@@ -2,9 +2,9 @@ import requests
 import urllib.parse
 from typing import Dict, Any, Optional, List, Union
 
-class DomeAPIClient:
+class PredictionMarketAPIClient:
     """
-    Client for Dome API with base URL changed to api.aisa.one/apis/v1.
+    Client for the AIsa API proxy for prediction market data.
     Provides access to Polymarket, Kalshi, and Matching Markets.
     """
     
@@ -12,7 +12,7 @@ class DomeAPIClient:
     
     def __init__(self, api_key: Optional[str] = None):
         """
-        Initialize the Dome API client.
+        Initialize the AIsa API proxy client.
         
         Args:
             api_key: Optional API key. Can be passed in headers or query params.
@@ -253,7 +253,7 @@ class DomeAPIClient:
     def place_order(self, signed_order: Dict[str, Any], order_type: str, 
                     credentials: Dict[str, str], client_order_id: Optional[str] = None) -> Dict[str, Any]:
         """
-        Places an order on Polymarket via Dome server.
+        Places an order on Polymarket via the AIsa API proxy.
         Note: This is a direct REST API call.
         """
         payload = {
@@ -273,5 +273,5 @@ class DomeAPIClient:
 
 # Example usage:
 if __name__ == "__main__":
-    client = DomeAPIClient(api_key="your_api_key_here")
+    client = PredictionMarketAPIClient(api_key="your_api_key_here")
     # print(client.get_polymarket_market_price("19701256321759583954581192053894521654935987478209343000964756587964612528044"))

--- a/dome-api/scripts/client.py
+++ b/dome-api/scripts/client.py
@@ -1,0 +1,277 @@
+import requests
+import urllib.parse
+from typing import Dict, Any, Optional, List, Union
+
+class DomeAPIClient:
+    """
+    Client for Dome API with base URL changed to api.aisa.one/apis/v1.
+    Provides access to Polymarket, Kalshi, and Matching Markets.
+    """
+    
+    BASE_URL = "https://api.aisa.one/apis/v1"
+    
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialize the Dome API client.
+        
+        Args:
+            api_key: Optional API key. Can be passed in headers or query params.
+        """
+        self.api_key = api_key
+        self.session = requests.Session()
+        if self.api_key:
+            self.session.headers.update({"Authorization": f"Bearer {self.api_key}"})
+            
+    def _request(self, method: str, endpoint: str, params: Optional[Dict[str, Any]] = None, json_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Make an HTTP request to the API."""
+        url = f"{self.BASE_URL}{endpoint}"
+        
+        # Clean up None values from params
+        if params:
+            params = {k: v for k, v in params.items() if v is not None}
+            
+        response = self.session.request(method, url, params=params, json=json_data)
+        response.raise_for_status()
+        return response.json()
+
+    # ==========================================
+    # Polymarket Endpoints
+    # ==========================================
+
+    def get_polymarket_events(self, event_slug: Optional[str] = None, tags: Optional[List[str]] = None, 
+                              status: Optional[str] = None, include_markets: Optional[bool] = None,
+                              start_time: Optional[int] = None, end_time: Optional[int] = None,
+                              game_start_time: Optional[int] = None, limit: int = 10, 
+                              pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """List events on Polymarket with filtering."""
+        params = {
+            "event_slug": event_slug,
+            "status": status,
+            "include_markets": str(include_markets).lower() if include_markets is not None else None,
+            "start_time": start_time,
+            "end_time": end_time,
+            "game_start_time": game_start_time,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        if tags:
+            params["tags"] = tags
+            
+        return self._request("GET", "/polymarket/events", params=params)
+
+    def get_polymarket_markets(self, market_slug: Optional[List[str]] = None, event_slug: Optional[List[str]] = None,
+                               condition_id: Optional[List[str]] = None, token_id: Optional[List[str]] = None,
+                               tags: Optional[List[str]] = None, search: Optional[str] = None,
+                               status: Optional[str] = None, min_volume: Optional[float] = None,
+                               limit: int = 10, pagination_key: Optional[str] = None,
+                               start_time: Optional[int] = None, end_time: Optional[int] = None) -> Dict[str, Any]:
+        """Find markets on Polymarket using various filters."""
+        params = {
+            "search": urllib.parse.quote(search) if search else None,
+            "status": status,
+            "min_volume": min_volume,
+            "limit": limit,
+            "pagination_key": pagination_key,
+            "start_time": start_time,
+            "end_time": end_time
+        }
+        
+        # Add list parameters
+        if market_slug: params["market_slug"] = market_slug
+        if event_slug: params["event_slug"] = event_slug
+        if condition_id: params["condition_id"] = condition_id
+        if token_id: params["token_id"] = token_id
+        if tags: params["tags"] = tags
+            
+        return self._request("GET", "/polymarket/markets", params=params)
+
+    def get_polymarket_orders(self, market_slug: Optional[str] = None, condition_id: Optional[str] = None,
+                              token_id: Optional[str] = None, start_time: Optional[int] = None,
+                              end_time: Optional[int] = None, limit: int = 100,
+                              pagination_key: Optional[str] = None, user: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches historical trade data (orders) on Polymarket."""
+        params = {
+            "market_slug": market_slug,
+            "condition_id": condition_id,
+            "token_id": token_id,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": limit,
+            "pagination_key": pagination_key,
+            "user": user
+        }
+        return self._request("GET", "/polymarket/orders", params=params)
+
+    def get_polymarket_orderbooks(self, token_id: str, start_time: Optional[int] = None,
+                                  end_time: Optional[int] = None, limit: int = 100,
+                                  pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches historical orderbook snapshots for a specific asset."""
+        params = {
+            "token_id": token_id,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        return self._request("GET", "/polymarket/orderbooks", params=params)
+
+    def get_polymarket_activity(self, user: Optional[str] = None, start_time: Optional[int] = None,
+                                end_time: Optional[int] = None, market_slug: Optional[str] = None,
+                                condition_id: Optional[str] = None, limit: int = 100,
+                                pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches activity data including MERGES, SPLITS, and REDEEMS."""
+        params = {
+            "user": user,
+            "start_time": start_time,
+            "end_time": end_time,
+            "market_slug": market_slug,
+            "condition_id": condition_id,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        return self._request("GET", "/polymarket/activity", params=params)
+
+    def get_polymarket_market_price(self, token_id: str, at_time: Optional[int] = None) -> Dict[str, Any]:
+        """Fetches the current or historical market price for a market by token_id."""
+        params = {"at_time": at_time}
+        return self._request("GET", f"/polymarket/market-price/{token_id}", params=params)
+
+    def get_polymarket_candlesticks(self, condition_id: str, start_time: int, end_time: int, interval: int = 1) -> Dict[str, Any]:
+        """Fetches historical candlestick data for a market identified by condition_id."""
+        params = {
+            "start_time": start_time,
+            "end_time": end_time,
+            "interval": interval
+        }
+        return self._request("GET", f"/polymarket/candlesticks/{condition_id}", params=params)
+
+    def get_polymarket_positions(self, wallet_address: str, limit: int = 100, pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches all Polymarket positions for a proxy wallet address."""
+        params = {
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        return self._request("GET", f"/polymarket/positions/wallet/{wallet_address}", params=params)
+
+    def get_polymarket_wallet(self, eoa: Optional[str] = None, proxy: Optional[str] = None,
+                              handle: Optional[str] = None, with_metrics: bool = False,
+                              start_time: Optional[int] = None, end_time: Optional[int] = None) -> Dict[str, Any]:
+        """Fetches wallet information."""
+        params = {
+            "eoa": eoa,
+            "proxy": proxy,
+            "handle": handle,
+            "with_metrics": str(with_metrics).lower(),
+            "start_time": start_time,
+            "end_time": end_time
+        }
+        return self._request("GET", "/polymarket/wallet", params=params)
+
+    def get_polymarket_wallet_pnl(self, wallet_address: str, granularity: str,
+                                  start_time: Optional[int] = None, end_time: Optional[int] = None) -> Dict[str, Any]:
+        """Fetches the realized profit and loss (PnL) for a specific wallet address."""
+        params = {
+            "granularity": granularity,
+            "start_time": start_time,
+            "end_time": end_time
+        }
+        return self._request("GET", f"/polymarket/wallet/pnl/{wallet_address}", params=params)
+
+    # ==========================================
+    # Kalshi Endpoints
+    # ==========================================
+
+    def get_kalshi_markets(self, market_ticker: Optional[List[str]] = None, event_ticker: Optional[List[str]] = None,
+                           search: Optional[str] = None, status: Optional[str] = None,
+                           min_volume: Optional[float] = None, limit: int = 10,
+                           pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Find markets on Kalshi."""
+        params = {
+            "search": urllib.parse.quote(search) if search else None,
+            "status": status,
+            "min_volume": min_volume,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        if market_ticker: params["market_ticker"] = market_ticker
+        if event_ticker: params["event_ticker"] = event_ticker
+            
+        return self._request("GET", "/kalshi/markets", params=params)
+
+    def get_kalshi_trades(self, ticker: Optional[str] = None, start_time: Optional[int] = None,
+                          end_time: Optional[int] = None, limit: int = 100,
+                          pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches historical trade data for Kalshi markets."""
+        params = {
+            "ticker": ticker,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        return self._request("GET", "/kalshi/trades", params=params)
+
+    def get_kalshi_market_price(self, market_ticker: str, at_time: Optional[int] = None) -> Dict[str, Any]:
+        """Fetches the current market price for a Kalshi market."""
+        params = {"at_time": at_time}
+        return self._request("GET", f"/kalshi/market-price/{market_ticker}", params=params)
+
+    def get_kalshi_orderbooks(self, ticker: str, start_time: Optional[int] = None,
+                              end_time: Optional[int] = None, limit: int = 100,
+                              pagination_key: Optional[str] = None) -> Dict[str, Any]:
+        """Fetches historical orderbook snapshots for a specific Kalshi market."""
+        params = {
+            "ticker": ticker,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": limit,
+            "pagination_key": pagination_key
+        }
+        return self._request("GET", "/kalshi/orderbooks", params=params)
+
+    # ==========================================
+    # Matching Markets Endpoints
+    # ==========================================
+
+    def get_matching_sports(self, polymarket_market_slug: Optional[List[str]] = None,
+                            kalshi_event_ticker: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Find equivalent markets across platforms for sports events."""
+        params = {}
+        if polymarket_market_slug: params["polymarket_market_slug"] = polymarket_market_slug
+        if kalshi_event_ticker: params["kalshi_event_ticker"] = kalshi_event_ticker
+        return self._request("GET", "/matching-markets/sports", params=params)
+
+    def get_matching_sport_by_date(self, sport: str, date: str) -> Dict[str, Any]:
+        """Find equivalent markets across platforms for sports events by sport and date."""
+        params = {"date": date}
+        return self._request("GET", f"/matching-markets/sports/{sport}", params=params)
+
+    # ==========================================
+    # Order Router
+    # ==========================================
+    
+    def place_order(self, signed_order: Dict[str, Any], order_type: str, 
+                    credentials: Dict[str, str], client_order_id: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Places an order on Polymarket via Dome server.
+        Note: This is a direct REST API call.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "placeOrder",
+            "id": client_order_id or "unique-request-id",
+            "params": {
+                "signedOrder": signed_order,
+                "orderType": order_type,
+                "credentials": credentials
+            }
+        }
+        if client_order_id:
+            payload["params"]["clientOrderId"] = client_order_id
+            
+        return self._request("POST", "/polymarket/placeOrder", json_data=payload)
+
+# Example usage:
+if __name__ == "__main__":
+    client = DomeAPIClient(api_key="your_api_key_here")
+    # print(client.get_polymarket_market_price("19701256321759583954581192053894521654935987478209343000964756587964612528044"))

--- a/dome-api/scripts/test_client.py
+++ b/dome-api/scripts/test_client.py
@@ -1,0 +1,340 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import urllib.parse
+
+from client import PredictionMarketAPIClient
+
+class TestPredictionMarketAPIClient(unittest.TestCase):
+    
+    def setUp(self):
+        self.api_key = "test_api_key_123"
+        self.client = PredictionMarketAPIClient(api_key=self.api_key)
+        self.client_no_auth = PredictionMarketAPIClient()
+
+    def test_init_with_api_key(self):
+        """Test client initialization with API key."""
+        self.assertEqual(self.client.api_key, self.api_key)
+        self.assertEqual(self.client.session.headers.get("Authorization"), f"Bearer {self.api_key}")
+
+    def test_init_without_api_key(self):
+        """Test client initialization without API key."""
+        self.assertIsNone(self.client_no_auth.api_key)
+        self.assertIsNone(self.client_no_auth.session.headers.get("Authorization"))
+
+    @patch('client.requests.Session.request')
+    def test_request_strips_none_params(self, mock_request):
+        """Test that _request removes None values from params."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"success": True}
+        mock_request.return_value = mock_response
+
+        self.client._request("GET", "/test", params={"a": 1, "b": None, "c": "test"})
+        
+        mock_request.assert_called_once_with(
+            "GET", 
+            "https://api.aisa.one/apis/v1/test", 
+            params={"a": 1, "c": "test"}, 
+            json=None
+        )
+
+    @patch('client.requests.Session.request')
+    def test_request_raises_for_status(self, mock_request):
+        """Test that _request raises an exception for HTTP errors."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("HTTP Error")
+        mock_request.return_value = mock_response
+
+        with self.assertRaises(Exception):
+            self.client._request("GET", "/test")
+
+    # ==========================================
+    # Polymarket Endpoints Tests
+    # ==========================================
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_events(self, mock_request):
+        """Test get_polymarket_events method."""
+        self.client.get_polymarket_events(
+            event_slug="test-event", 
+            include_markets=True, 
+            tags=["sports", "politics"]
+        )
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/events", 
+            params={
+                "event_slug": "test-event",
+                "status": None,
+                "include_markets": "true",
+                "start_time": None,
+                "end_time": None,
+                "game_start_time": None,
+                "limit": 10,
+                "pagination_key": None,
+                "tags": ["sports", "politics"]
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_markets(self, mock_request):
+        """Test get_polymarket_markets method, including URL encoding of search."""
+        self.client.get_polymarket_markets(
+            search="bitcoin & crypto", 
+            market_slug=["slug1", "slug2"]
+        )
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/markets", 
+            params={
+                "search": urllib.parse.quote("bitcoin & crypto"),
+                "status": None,
+                "min_volume": None,
+                "limit": 10,
+                "pagination_key": None,
+                "start_time": None,
+                "end_time": None,
+                "market_slug": ["slug1", "slug2"]
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_orders(self, mock_request):
+        """Test get_polymarket_orders method."""
+        self.client.get_polymarket_orders(token_id="token123", limit=50)
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/orders", 
+            params={
+                "market_slug": None,
+                "condition_id": None,
+                "token_id": "token123",
+                "start_time": None,
+                "end_time": None,
+                "limit": 50,
+                "pagination_key": None,
+                "user": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_orderbooks(self, mock_request):
+        """Test get_polymarket_orderbooks method."""
+        self.client.get_polymarket_orderbooks(token_id="token123")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/orderbooks", 
+            params={
+                "token_id": "token123",
+                "start_time": None,
+                "end_time": None,
+                "limit": 100,
+                "pagination_key": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_activity(self, mock_request):
+        """Test get_polymarket_activity method."""
+        self.client.get_polymarket_activity(user="user123")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/activity", 
+            params={
+                "user": "user123",
+                "start_time": None,
+                "end_time": None,
+                "market_slug": None,
+                "condition_id": None,
+                "limit": 100,
+                "pagination_key": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_market_price(self, mock_request):
+        """Test get_polymarket_market_price method."""
+        self.client.get_polymarket_market_price(token_id="token123", at_time=123456789)
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/market-price/token123", 
+            params={"at_time": 123456789}
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_candlesticks(self, mock_request):
+        """Test get_polymarket_candlesticks method."""
+        self.client.get_polymarket_candlesticks(condition_id="cond123", start_time=100, end_time=200)
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/candlesticks/cond123", 
+            params={
+                "start_time": 100,
+                "end_time": 200,
+                "interval": 1
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_positions(self, mock_request):
+        """Test get_polymarket_positions method."""
+        self.client.get_polymarket_positions(wallet_address="0xABC")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/positions/wallet/0xABC", 
+            params={
+                "limit": 100,
+                "pagination_key": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_wallet(self, mock_request):
+        """Test get_polymarket_wallet method."""
+        self.client.get_polymarket_wallet(eoa="0xDEF", with_metrics=True)
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/wallet", 
+            params={
+                "eoa": "0xDEF",
+                "proxy": None,
+                "handle": None,
+                "with_metrics": "true",
+                "start_time": None,
+                "end_time": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_polymarket_wallet_pnl(self, mock_request):
+        """Test get_polymarket_wallet_pnl method."""
+        self.client.get_polymarket_wallet_pnl(wallet_address="0xABC", granularity="day")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/polymarket/wallet/pnl/0xABC", 
+            params={
+                "granularity": "day",
+                "start_time": None,
+                "end_time": None
+            }
+        )
+
+    # ==========================================
+    # Kalshi Endpoints Tests
+    # ==========================================
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_kalshi_markets(self, mock_request):
+        """Test get_kalshi_markets method."""
+        self.client.get_kalshi_markets(search="election", market_ticker=["TICK1"])
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/kalshi/markets", 
+            params={
+                "search": urllib.parse.quote("election"),
+                "status": None,
+                "min_volume": None,
+                "limit": 10,
+                "pagination_key": None,
+                "market_ticker": ["TICK1"]
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_kalshi_trades(self, mock_request):
+        """Test get_kalshi_trades method."""
+        self.client.get_kalshi_trades(ticker="TICK1")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/kalshi/trades", 
+            params={
+                "ticker": "TICK1",
+                "start_time": None,
+                "end_time": None,
+                "limit": 100,
+                "pagination_key": None
+            }
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_kalshi_market_price(self, mock_request):
+        """Test get_kalshi_market_price method."""
+        self.client.get_kalshi_market_price(market_ticker="TICK1")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/kalshi/market-price/TICK1", 
+            params={"at_time": None}
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_kalshi_orderbooks(self, mock_request):
+        """Test get_kalshi_orderbooks method."""
+        self.client.get_kalshi_orderbooks(ticker="TICK1")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/kalshi/orderbooks", 
+            params={
+                "ticker": "TICK1",
+                "start_time": None,
+                "end_time": None,
+                "limit": 100,
+                "pagination_key": None
+            }
+        )
+
+    # ==========================================
+    # Matching Markets Endpoints Tests
+    # ==========================================
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_matching_sports(self, mock_request):
+        """Test get_matching_sports method."""
+        self.client.get_matching_sports(polymarket_market_slug=["slug1"])
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/matching-markets/sports", 
+            params={"polymarket_market_slug": ["slug1"]}
+        )
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_get_matching_sport_by_date(self, mock_request):
+        """Test get_matching_sport_by_date method."""
+        self.client.get_matching_sport_by_date(sport="nfl", date="2024-01-01")
+        mock_request.assert_called_once_with(
+            "GET", 
+            "/matching-markets/sports/nfl", 
+            params={"date": "2024-01-01"}
+        )
+
+    # ==========================================
+    # Order Router Tests
+    # ==========================================
+
+    @patch('client.PredictionMarketAPIClient._request')
+    def test_place_order(self, mock_request):
+        """Test place_order method."""
+        signed_order = {"price": 0.5, "size": 10}
+        credentials = {"key": "val"}
+        self.client.place_order(
+            signed_order=signed_order, 
+            order_type="LIMIT", 
+            credentials=credentials, 
+            client_order_id="my-id-123"
+        )
+        mock_request.assert_called_once_with(
+            "POST", 
+            "/polymarket/placeOrder", 
+            json_data={
+                "jsonrpc": "2.0",
+                "method": "placeOrder",
+                "id": "my-id-123",
+                "params": {
+                    "signedOrder": signed_order,
+                    "orderType": "LIMIT",
+                    "credentials": credentials,
+                    "clientOrderId": "my-id-123"
+                }
+            }
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a new **dome-api** skill with a SKILL.md and Python client script.

## What's included
- **SKILL.md** — Full endpoint documentation for Polymarket, Kalshi, Matching Markets, Order Router, and Websockets
- **scripts/client.py** — Python client class (`DomeAPIClient`) implementing all major REST endpoints

## Base URL
All endpoints use the AIsa proxy: `https://api.aisa.one/apis/v1`

## Endpoints covered
| Platform | Endpoints |
|----------|-----------|
| Polymarket | Markets, Events, Orders, Orderbooks, Activity, Market Price, Candlesticks, Positions, Wallet, Wallet PnL |
| Kalshi | Markets, Trades, Market Price, Orderbooks |
| Matching Markets | Sports, Sport by Date |
| Order Router | Place Order (POST) |

Crypto prices endpoints (Binance, Chainlink) were intentionally excluded per requirements.