### PR TITLE
Add Polymarket API endpoint documentation

### DIFF
--- a/reference/Prediction Market API/Polymarket/_order.yaml
+++ b/reference/Prediction Market API/Polymarket/_order.yaml
@@ -1,0 +1,10 @@
+- get_polymarket-markets
+- get_polymarket-events
+- get_polymarket-orders
+- get_polymarket-orderbooks
+- get_polymarket-activity
+- get_polymarket-market-price
+- get_polymarket-candlesticks
+- get_polymarket-positions
+- get_polymarket-wallet
+- get_polymarket-wallet-pnl

--- a/reference/Prediction Market API/Polymarket/get_polymarket-activity.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-activity.md
@@ -1,0 +1,25 @@
+---
+title: Activity
+excerpt: Fetches trading activity data including merges, splits, and redeems with optional filtering by user, market, and time range.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-activity
+hidden: false
+---
+Activity fetches on-chain trading activity from Polymarket with optional filtering by user wallet, market, condition, and time range. Returns activity records including MERGES, SPLITS, and REDEEMS, which represent the different types of position management operations on the platform.
+
+**Best for:** Tracking wallet activity, monitoring position changes, analyzing redemption patterns, auditing on-chain trading operations.
+
+**Endpoint:** `GET /polymarket/activity`
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/activity?user=0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b&limit=50" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns an `activities` array containing activity objects with fields such as side (MERGE/SPLIT/REDEEM), shares, price, transaction hash, timestamp, and user wallet address. A `pagination` object with `has_more` and `pagination_key` fields supports cursor-based pagination through large result sets.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-candlesticks.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-candlesticks.md
@@ -1,0 +1,27 @@
+---
+title: Candlesticks
+excerpt: Fetches historical candlestick data for a market identified by condition ID over a specified interval.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-candlesticks
+hidden: false
+---
+Candlesticks fetches historical OHLC (open, high, low, close) candlestick data for a Polymarket market identified by its condition ID. Data is returned over a specified time range at configurable intervals (1-minute, 1-hour, or 1-day). Each candlestick includes price data, volume, open interest, and bid/ask spreads.
+
+**Best for:** Building price charts, technical analysis, tracking market volatility, visualizing price movements over time.
+
+**Endpoint:** `GET /polymarket/candlesticks/{condition_id}`
+
+> **Note:** There are range limits per interval: 1-minute intervals support a maximum range of 1 week, 1-hour intervals support 1 month, and 1-day intervals support 1 year.
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/candlesticks/0x6876ac2b6174778c973c118aac287c49057c4d5360f896729209fe985a2c07fb?start_time=1640995200&end_time=1672531200&interval=1440" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns a `candlesticks` array where each element is a tuple of a candlestick data array and token metadata. Each candlestick data object contains OHLC prices (in both raw and dollar values), volume, open interest, and yes-side bid/ask spreads. The token metadata includes the token ID and outcome label (e.g., "Yes", "No").

--- a/reference/Prediction Market API/Polymarket/get_polymarket-events.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-events.md
@@ -1,0 +1,25 @@
+---
+title: Events
+excerpt: List events (groups of related markets) on Polymarket with filtering by category and status.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-events
+hidden: false
+---
+Events fetches groups of related prediction markets from Polymarket. Events aggregate multiple markets under a single topic (e.g., "Presidential Election 2024" contains multiple candidate markets). Returns events ordered by total volume (most popular first), with optional filtering by event slug, tags, and status.
+
+**Best for:** Browsing prediction market categories, finding related markets grouped by topic, tracking high-volume event clusters.
+
+**Endpoint:** `GET /polymarket/events`
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/events?tags=politics&status=open&include_markets=true&limit=5" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns an `events` array containing event objects with fields such as title, status, volume, tags, and market count. When `include_markets=true` is set, each event includes a nested `markets` array with its associated markets. A `pagination` object with `has_more` and `pagination_key` fields supports cursor-based pagination.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-market-price.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-market-price.md
@@ -1,0 +1,25 @@
+---
+title: Market Price
+excerpt: Fetches the current or historical market price for a market by token ID.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-market-price
+hidden: false
+---
+Market Price fetches the current or historical price for a Polymarket market identified by its token ID. When the `at_time` parameter is omitted, it returns the most real-time price available. When `at_time` is provided, it returns the historical market price at that specific timestamp.
+
+**Best for:** Real-time price lookups, historical price snapshots, building price charts, tracking market sentiment over time.
+
+**Endpoint:** `GET /polymarket/market-price/{token_id}`
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/market-price/19701256321759583954581192053894521654935987478209343000964756587964612528044?at_time=1762164600" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns a `price` field (a number between 0 and 1 representing the market probability) and an `at_time` field (Unix timestamp in seconds) indicating the point in time for which the price was fetched.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-markets.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-markets.md
@@ -1,0 +1,25 @@
+---
+title: Markets
+excerpt: Find markets on Polymarket using various filters including the ability to search.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-markets
+hidden: false
+---
+Markets fetches prediction market data from Polymarket with optional filtering and search functionality. Supports filtering by market slug, condition ID, token ID, or tags, as well as fuzzy search across market titles and descriptions. Returns markets ordered by volume (most popular first) when filters are applied, or by start time (most recent first) when no filters are provided.
+
+**Best for:** Discovering prediction markets, filtering by topic or status, searching for specific events, tracking market volume and outcomes.
+
+**Endpoint:** `GET /polymarket/markets`
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/markets?search=bitcoin&status=open&limit=5" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns a `markets` array containing market objects with details such as title, status, volume, sides/outcomes, and timing information. A `pagination` object is also included with `has_more` and `pagination_key` fields for cursor-based pagination through large result sets.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-orderbooks.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-orderbooks.md
@@ -1,0 +1,27 @@
+---
+title: Orderbook History
+excerpt: Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-orderbooks
+hidden: false
+---
+Orderbook History fetches historical orderbook snapshots for a specific Polymarket asset (token ID) over a specified time range. If no start and end times are provided, it returns the latest orderbook snapshot for the market. Returns snapshots of the order book including bids, asks, and market metadata.
+
+**Best for:** Analyzing market depth, tracking bid/ask spread over time, building orderbook visualizations, monitoring liquidity.
+
+**Endpoint:** `GET /polymarket/orderbooks`
+
+> **Note:** All timestamps are in milliseconds. Orderbook data has history starting from October 14th, 2025. When fetching the latest orderbook (without start/end times), the `limit` and `pagination_key` parameters are ignored.
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/orderbooks?token_id=56369772478534954338683665819559528414197495274302917800610633957542171787417&start_time=1760470000000&end_time=1760480000000&limit=100" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns a `snapshots` array containing orderbook snapshot objects, each with `bids` and `asks` arrays (containing size and price), along with metadata such as asset ID, timestamp, tick size, and market condition ID. A `pagination` object with `has_more` and `pagination_key` fields supports cursor-based pagination.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-orders.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-orders.md
@@ -1,0 +1,27 @@
+---
+title: Trade History
+excerpt: Fetches historical trade data with optional filtering by market, condition, token, time range, and user wallet address.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-orders
+hidden: false
+---
+Trade History fetches order data from Polymarket with optional filtering by market, condition, token, time range, and user wallet address. Returns orders that match either primary or secondary token IDs for markets. If no filters are provided, it returns the latest trades happening in real time.
+
+**Best for:** Analyzing trading activity, tracking specific wallet addresses, monitoring real-time trades, building trade history for a market.
+
+**Endpoint:** `GET /polymarket/orders`
+
+> **Note:** Only one of `market_slug`, `token_id`, or `condition_id` can be provided per request.
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/orders?market_slug=bitcoin-up-or-down-july-25-8pm-et&limit=50" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns an `orders` array containing trade objects with fields such as token ID, side (BUY/SELL), shares, price, transaction hash, timestamp, and user/taker wallet addresses. A `pagination` object with `has_more` and `pagination_key` fields supports cursor-based pagination through large result sets.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-positions.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-positions.md
@@ -1,0 +1,25 @@
+---
+title: Positions
+excerpt: Fetches all Polymarket positions for a proxy wallet address with market info and redemption status.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-positions
+hidden: false
+---
+Positions fetches all active Polymarket positions held by a specific proxy wallet address. Returns positions with a balance of at least 10,000 shares (0.01 normalized), along with detailed market information including title, status, outcome labels, and redemption eligibility.
+
+**Best for:** Portfolio tracking, monitoring wallet holdings, identifying redeemable positions, analyzing wallet exposure across markets.
+
+**Endpoint:** `GET /polymarket/positions/wallet/{wallet_address}`
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/positions/wallet/0x1234567890abcdef1234567890abcdef12345678?limit=100" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns a `wallet_address` field, a `positions` array containing position objects with fields such as token ID, condition ID, title, shares (raw and normalized), redeemable status, market/event slugs, outcome label, winning outcome, and market status. A `pagination` object with `has_more` and `pagination_key` fields supports cursor-based pagination.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-wallet-pnl.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-wallet-pnl.md
@@ -1,0 +1,27 @@
+---
+title: Wallet Profit-and-Loss
+excerpt: Fetches realized profit and loss (PnL) for a wallet address over a specified time range and granularity.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-wallet-pnl
+hidden: false
+---
+Wallet Profit-and-Loss fetches the realized PnL for a specific Polymarket wallet address over a specified time range and granularity. This tracks realized gains only, from either confirmed sells or redeems. A gain or loss is not realized until a finished market is redeemed.
+
+**Best for:** Tracking wallet profitability, analyzing trading performance over time, building PnL dashboards, comparing realized returns across periods.
+
+**Endpoint:** `GET /polymarket/wallet/pnl/{wallet_address}`
+
+> **Note:** This returns realized PnL only, which differs from Polymarket's dashboard that shows historical unrealized PnL.
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/wallet/pnl/0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b?granularity=day&start_time=1726857600&end_time=1758316829" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns the `granularity`, `start_time`, `end_time`, and `wallet_address` fields, along with a `pnl_over_time` array. Each element in the array contains a `timestamp` and `pnl_to_date` value representing the cumulative realized profit and loss at that point in time.

--- a/reference/Prediction Market API/Polymarket/get_polymarket-wallet.md
+++ b/reference/Prediction Market API/Polymarket/get_polymarket-wallet.md
@@ -1,0 +1,27 @@
+---
+title: Wallet
+excerpt: Fetches wallet information by EOA address, proxy address, or user handle, with optional trading metrics.
+api:
+  file: polymarket-openapi.json
+  operationId: get_polymarket-wallet
+hidden: false
+---
+Wallet fetches Polymarket wallet information by providing either an EOA (Externally Owned Account) address, a proxy wallet address, or a user handle. Returns the associated EOA, proxy, wallet type, handle, pseudonym, and profile image. Optionally includes trading metrics such as total volume, number of trades, and unique markets traded when `with_metrics=true`.
+
+**Best for:** Looking up wallet identities, resolving handles to addresses, retrieving user profiles, analyzing wallet trading performance.
+
+**Endpoint:** `GET /polymarket/wallet`
+
+> **Note:** Exactly one of `eoa`, `proxy`, or `handle` must be provided per request.
+
+### Example
+
+```bash
+curl -X GET "https://api.aisa.one/apis/v1/polymarket/wallet?handle=satoshi&with_metrics=true" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+### Response
+
+The response returns wallet identity fields including `eoa`, `proxy`, `wallet_type`, `handle`, `pseudonym`, and `image`. When `with_metrics=true` is set, a `wallet_metrics` object is also included with total volume, total trades, total markets, highest volume day, and counts for merges, splits, conversions, and redemptions.


### PR DESCRIPTION
## Summary
This PR adds comprehensive API documentation for 10 new Polymarket endpoints, enabling users to interact with prediction market data including markets, trading activity, wallet information, and historical price data.

## Key Changes
- **Markets & Events**: Added documentation for discovering and filtering prediction markets and event groupings
- **Trading Data**: Documented endpoints for trade history, orderbook snapshots, and candlestick OHLC data
- **Wallet Features**: Added wallet lookup, position tracking, and profit-and-loss calculation endpoints
- **Activity Tracking**: Documented on-chain activity monitoring for merges, splits, and redemptions
- **Price Data**: Added market price and historical price snapshot endpoints
- **Navigation**: Created `_order.yaml` to define the logical ordering of endpoints in the documentation

## Notable Details
- Each endpoint includes clear use cases, example curl requests, and response structure descriptions
- Documentation covers important constraints (e.g., 1-minute candlesticks limited to 1-week ranges, orderbook history starting October 14, 2025)
- All endpoints support pagination with cursor-based navigation where applicable
- Wallet endpoints support multiple lookup methods (EOA address, proxy address, or user handle)
- PnL tracking explicitly notes it returns realized gains only, distinguishing from unrealized PnL shown in Polymarket's dashboard

https://claude.ai/code/session_014KsfFyL2Ax7wMtUiFacqEx