### PR TITLE
fix(twitter): use is_success_response for relay result check

### DIFF
--- a/twitter/scripts/twitter_engagement_client.py
+++ b/twitter/scripts/twitter_engagement_client.py
@@ -351,7 +351,7 @@ def execute_tweet_action(
         "tweet_id": tweet_id.strip(),
     }
     relay_result = relay_action(config, endpoint, payload)
-    ok = relay_result.get("ok") is not False and relay_result.get("code") == 200
+    ok = relay_result.get("ok") is not False and is_success_response(relay_result)
     response = {
         "ok": ok,
         "action": action,
@@ -384,7 +384,7 @@ def execute_user_action(
         "target_user_id": target_user_id.strip(),
     }
     relay_result = relay_action(config, endpoint, payload)
-    ok = relay_result.get("ok") is not False and relay_result.get("code") == 200
+    ok = relay_result.get("ok") is not False and is_success_response(relay_result)
     response = {
         "ok": ok,
         "action": action,


### PR DESCRIPTION
## Summary
- The hardcoded `code == 200` check in `execute_tweet_action` / `execute_user_action` marked successful relay responses as failures when the relay returned `status: "success"` or `code: 0`.
- Switched to `is_success_response(relay_result)` to match the rest of the file.

## Test plan
- [ ] Run `like-latest` / `follow-user` against a relay returning `{"status":"success"}` and confirm `ok: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)