### PR TITLE
Rename 'AIsa Media Gen' to 'Media Gen'

### DIFF
--- a/media-gen/README.md
+++ b/media-gen/README.md
@@ -1,4 +1,4 @@
-## AIsa Media Gen
+## Media Gen
 
 Generate images and videos using the AIsa API:
 

--- a/media-gen/SKILL.md
+++ b/media-gen/SKILL.md
@@ -5,7 +5,7 @@ homepage: https://aisa.one
 metadata: {"aisa":{"emoji":"🎬","requires":{"bins":["python3","curl"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY","compatibility":["openclaw","claude-code","hermes"]}}
 ---
 
-# AIsa Media Gen 🎬
+# Media Gen 🎬
 
 Generate **images** and **videos** with a single AIsa API key:
 

--- a/media-gen/scripts/media_gen_client.py
+++ b/media-gen/scripts/media_gen_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-AIsa Media Gen - AIsa API Client
+Media Gen - AIsa API Client
 
 Image:
   - Gemini GenerateContent: POST https://api.aisa.one/v1/models/{model}:generateContent
@@ -290,7 +290,7 @@ def cmd_video_wait(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="AIsa Media Gen - image & video generation")
+    p = argparse.ArgumentParser(description="Media Gen - image & video generation")
     p.add_argument("--api-key", help="Override AISA_API_KEY")
 
     sub = p.add_subparsers(dest="command")


### PR DESCRIPTION
## Summary
- Renames the user-visible name from `AIsa Media Gen` to `Media Gen` in the `media-gen` skill
- Touches: `media-gen/README.md` (H2), `media-gen/SKILL.md` (H1), and `media-gen/scripts/media_gen_client.py` (docstring + argparse description)

## Not changed
- Folder name (`media-gen/`) — unchanged
- SKILL.md frontmatter `name: aisa-media-gen` — unchanged (slug-style id; let me know if you want this updated too)

## Test plan
- [ ] `python media-gen/scripts/media_gen_client.py --help` shows the new description
- [ ] No remaining `AIsa Media Gen` strings in repo (`grep -r 'AIsa Media Gen'`)