### PR TITLE
Fix broken video task-status poll URL in media-gen client

### DIFF
--- a/media-gen/SKILL.md
+++ b/media-gen/SKILL.md
@@ -92,12 +92,12 @@ curl -X POST "https://api.aisa.one/apis/v1/services/aigc/video-generation/video-
 
 ### Poll task
 
-- `GET /services/aigc/tasks?task_id=...`
+- `GET /services/aigc/tasks/{task_id}` — `task_id` is a **path parameter**. The query-string form `?task_id=...` returns HTTP 500 `unsupported uri`.
 
-Documentation: `task` at `https://docs.aisa.one/reference/get_services-aigc-tasks`.
+Documentation: [Get video generation task result](https://aisa.mintlify.app/api-reference/video/get_services-aigc-tasks).
 
 ```bash
-curl "https://api.aisa.one/apis/v1/services/aigc/tasks?task_id=YOUR_TASK_ID" \
+curl "https://api.aisa.one/apis/v1/services/aigc/tasks/YOUR_TASK_ID" \
   -H "Authorization: Bearer $AISA_API_KEY"
 ```
 

--- a/media-gen/scripts/media_gen_client.py
+++ b/media-gen/scripts/media_gen_client.py
@@ -8,7 +8,7 @@ Image:
 Video:
   - Wan 2.6 async task:
       POST https://api.aisa.one/apis/v1/services/aigc/video-generation/video-synthesis
-      GET  https://api.aisa.one/apis/v1/services/aigc/tasks?task_id=...
+      GET  https://api.aisa.one/apis/v1/services/aigc/tasks/{task_id}
 """
 
 from __future__ import annotations
@@ -192,7 +192,10 @@ def video_create_task(
 
 
 def video_task_status(*, api_key: str, task_id: str) -> Dict[str, Any]:
-    url = f"{VIDEO_BASE_URL}/services/aigc/tasks?{urllib.parse.urlencode({'task_id': task_id})}"
+    # task_id is a PATH parameter, not a query string. The query-string form
+    # returns HTTP 500 "unsupported uri".
+    safe_id = urllib.parse.quote(task_id, safe="")
+    url = f"{VIDEO_BASE_URL}/services/aigc/tasks/{safe_id}"
     return _http_request_json(method="GET", url=url, api_key=api_key, timeout_s=60)
 
 


### PR DESCRIPTION
## Summary

Fix the broken video task-status poll URL in the media-gen skill client.

## Bug

`video_task_status()` built the URL like this:

```python
url = f"{VIDEO_BASE_URL}/services/aigc/tasks?{urllib.parse.urlencode({'task_id': task_id})}"
```

Against the AIsa gateway that returns:

```
HTTP 500  {"error": "unsupported uri"}
```

The gateway requires `task_id` as a **path parameter**:

```
GET /apis/v1/services/aigc/tasks/{task_id}
```

### Impact

Today, `python3 media_gen_client.py video-wait` or `video-status` always fails after the initial task creation — even for tasks that actually completed upstream, you can never retrieve their video URL via this client.

## Fix

```python
safe_id = urllib.parse.quote(task_id, safe="")
url = f"{VIDEO_BASE_URL}/services/aigc/tasks/{safe_id}"
```

Also updated:
- The module docstring (line 8-11) which documented the wrong URL
- `media-gen/SKILL.md` — "Poll task" section and the curl example; switched the doc link to the new Mintlify URL

## Verification

Generated a real `wan2.6-t2v` task end-to-end (`a36d5b42-f2ff-4e87-a59e-2b1ca6b2fc04`, 5 s 720P prompt) and confirmed the fixed client returns the real SUCCEEDED payload:

```json
{
  "output": {
    "task_id": "a36d5b42-...",
    "task_status": "SUCCEEDED",
    "video_url": "https://dashscope-463f.oss-accelerate.aliyuncs.com/...mp4",
    "orig_prompt": "a single red apple on a white background, rotating slowly, cinematic lighting",
    "submit_time": "2026-04-18 15:37:35.524",
    "scheduled_time": "2026-04-18 15:37:35.550",
    "end_time": "2026-04-18 15:41:25.850"
  },
  "usage": {
    "SR": 1080,
    "duration": 5,
    "input_video_duration": 0,
    "output_video_duration": 5,
    "size": "1920*1080",
    "video_count": 1
  },
  "request_id": "..."
}
```

## Related docs-side fix

[AIsa-team/docs PR #11](https://github.com/AIsa-team/docs/pull/11) fixes the same path in the Mintlify docs (`openapi/aliyun-video.json`, `api-reference/async-operations.mdx`, `api-reference/video/get_services-aigc-tasks.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
