### PR TITLE
docs: rewrite README and align SKILL.md with sibling skill format

### DIFF
--- a/last30days/README.md
+++ b/last30days/README.md
@@ -1,25 +1,89 @@
 # last30days
 
-English ClawHub publish bundle for `last30days`.
+Multi-source research skill for the last 30 days. One command pulls a
+ranked, clustered brief on any topic across eight sources: Reddit, X,
+YouTube, TikTok, Instagram, Hacker News, Polymarket, and grounded web
+search — in ~40 seconds.
 
-Included:
+## Quick start
 
-- runtime scripts
-- `SKILL.md`
-- `.codex-plugin/plugin.json`
-- license and package metadata
+```bash
+# 1. Set your AIsa key
+export AISA_API_KEY=sk-...
 
-Excluded on purpose:
+# 2. First-run setup (interactive model picker)
+bash scripts/run-last30days.sh setup
 
-- tests
-- historical docs
-- hooks
-- fixtures
-- Gemini-specific extension metadata
+# 3. Research a topic
+bash scripts/run-last30days.sh "OpenAI Agents SDK"
+```
 
-Runtime summary:
+## Examples
 
-- `AISA_API_KEY` powers hosted planning, reranking, synthesis, X/Twitter, YouTube, Polymarket, and grounded web search.
-- Reddit and Hacker News use public paths.
-- GitHub stays on the official GitHub API path and may need `GH_TOKEN` or `GITHUB_TOKEN`.
+```bash
+last30days "OpenAI Agents SDK"
+last30days "Claude Code vs Codex"
+last30days "Peter Steinberger"
+last30days "bitcoin price" --quick
+last30days "Perplexity" --emit=json
+```
 
+## What it returns
+
+A single markdown (or JSON) brief:
+
+- **Ranked evidence clusters** — top findings grouped by theme, each with
+  a URL, date, engagement stats, and a one-line "why relevant" rationale
+- **Stats** — items per source, top communities/domains/channels
+- **Best Takes** — quirky or meme-worthy items (cosmetic)
+- **Source coverage** — how many items each source contributed
+
+Pass `--emit=json` for a machine-readable version with the full
+`query_plan`, `ranked_candidates`, `clusters`, and `items_by_source`
+fields — suitable for feeding into another agent.
+
+## Requirements
+
+- **Python 3.12+**
+- **`AISA_API_KEY`** — powers the planner, reranker, fun-scorer, and
+  hosted retrieval for X, YouTube, TikTok, Instagram, Polymarket, and
+  grounded web search. Get one at [aisa.one](https://aisa.one).
+- **`GH_TOKEN` or `GITHUB_TOKEN`** *(optional)* — enables the GitHub
+  source. Without it the other seven sources still work.
+
+Reddit and Hacker News use public endpoints and need no credentials.
+
+## Per-role model configuration
+
+The skill makes three LLM calls per run: planner (query structure),
+reranker (relevance ranking), fun-scorer (quirkiness). Each can be pinned
+independently:
+
+```bash
+# ~/.config/last30days/.env
+LAST30DAYS_PLANNER_MODEL=qwen-flash           # fast + reliable JSON
+LAST30DAYS_RERANK_MODEL=qwen-plus-2025-12-01  # quality ranking
+LAST30DAYS_FUN_MODEL=qwen-flash               # cheap vibes
+```
+
+Or set `AISA_MODEL=...` for a single model across all three. The
+interactive `setup` flow walks you through picking from the live
+[AIsa model catalog](https://aisa.one/docs/guides/models).
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--quick` | Lower-latency retrieval profile (fewer candidates) |
+| `--deep` | Higher-recall retrieval profile |
+| `--emit=json` | Machine-readable output (default: markdown) |
+| `--search=reddit,x,hackernews` | Restrict to specific sources |
+| `--diagnose` | Print provider / source availability |
+| `--save-dir=out/` | Persist the rendered brief to disk |
+| `--store` | Persist findings to the local SQLite research store |
+
+Run `last30days --help` for the full list.
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/last30days/SKILL.md
+++ b/last30days/SKILL.md
@@ -1,57 +1,135 @@
 ---
 name: last30days
-version: "1.0.4"
-description: "Research the last 30 days across Reddit, X/Twitter, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and web search. Use when: you need recent social research, company updates, person profiles, competitor comparisons, launch reactions, or trend scans. Supports AISA-powered planning, clustering, reranking, and JSON output."
-argument-hint: "last30days OpenAI Agents SDK, last30days Peter Steinberger, last30days OpenClaw"
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
-homepage: https://github.com/AIsa-team/agent-skills
-repository: https://github.com/AIsa-team/agent-skills
-author: mvanhorn
-license: MIT
-user-invocable: true
-metadata:
-  openclaw:
-    emoji: "📰"
-    requires:
-      env:
-        - AISA_API_KEY
-      bins:
-        - python3
-        - bash
-    primaryEnv: AISA_API_KEY
-    files:
-      - "scripts/*"
+description: "Research the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web search. Returns a ranked, clustered brief with citations. Use when the task needs recent social evidence, competitor comparisons, launch reactions, trend scans, or person/company profiles."
+homepage: https://aisa.one
+metadata: {"aisa":{"emoji":"📰","requires":{"bins":["python3","bash"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY","compatibility":["openclaw","claude-code","hermes"]}}
 ---
 
-# last30days
+# last30days 📰
 
-Research recent evidence across social platforms, community forums, prediction markets, GitHub, and grounded web results, then merge everything into one brief.
+**30-day multi-source research brief for autonomous agents. Powered by AIsa.**
+
+One API key. Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web — merged into a single ranked brief.
+
+## What Can You Do?
+
+### Trend scan
+```text
+"last30days OpenAI Agents SDK"
+```
+
+### Competitor comparison
+```text
+"last30days Claude Code vs Codex"
+```
+
+### Person / company profile
+```text
+"last30days Peter Steinberger"
+```
+
+### Launch reaction
+```text
+"last30days GPT-5 launch --deep"
+```
+
+### Prediction-market angle
+```text
+"last30days bitcoin price"
+```
+
+## Quick Start
+
+```bash
+# 1. Export your AIsa key
+export AISA_API_KEY=sk-...
+
+# 2. First-run setup (interactive — picks planner / rerank / fun-scorer models)
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" setup
+
+# 3. Research a topic
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" "OpenAI Agents SDK"
+```
+
+## Common Flags
+
+```bash
+# Low-latency profile (fewer candidates per source)
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --quick
+
+# Higher-recall profile
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --deep
+
+# Machine-readable output (full plan + candidates + clusters)
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --emit=json
+
+# Restrict to specific sources
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --search=reddit,x,grounding
+
+# Check provider / source availability
+bash "${SKILL_ROOT}/scripts/run-last30days.sh" --diagnose
+```
+
+## Inputs and Outputs
+
+**Input.** A topic, person, company, product, or comparison — e.g.
+`OpenAI Agents SDK`, `OpenClaw vs Codex`, `Peter Steinberger`.
+
+**Output.** A markdown brief (default) or JSON with:
+
+- `query_plan` — planner-generated subqueries and source weights
+- `ranked_candidates` — reranked candidate pool with scores
+- `clusters` — semantically grouped findings
+- `items_by_source` — per-source item lists with dates, engagement, URLs
+- `provider_runtime` — which models + retrieval backends ran
+- `errors_by_source` — any source-level failures (fail-soft)
 
 ## When to use
 
-- Use when you need a last-30-days research brief on a person, company, product, market, tool, or trend.
-- Use when you want a recent competitor comparison, launch reaction summary, creator/community sentiment scan, or shipping update.
-- Use when you want structured JSON with `query_plan`, `ranked_candidates`, `clusters`, and `items_by_source`.
+- You need last-30-days evidence on a person, company, product, market, tool, or trend.
+- You want a ranked competitor comparison, launch-reaction summary, creator/community sentiment scan, or shipping update.
+- You want a structured JSON brief to feed into another agent.
 
 ## When NOT to use
 
-- Do not use for timeless encyclopedia questions with no recent evidence requirement.
-- Do not use when you need only one official source and do not want social/community signals.
+- Timeless reference questions with no recent-evidence requirement.
+- When you only want one official source and don't want social/community signals.
 
 ## Capabilities
 
-- AISA-hosted planning, reranking, synthesis, grounded web search, X/Twitter search, YouTube search, and Polymarket search.
-- Public Reddit and Hacker News retrieval with fail-soft behavior.
-- Official GitHub API search when `GH_TOKEN` or `GITHUB_TOKEN` is available.
-- Hosted discovery for TikTok, Instagram, Threads, and Pinterest when enabled in runtime config.
+- **AISA-powered**: planner (structured JSON query plan), reranker
+  (relevance ordering), fun-scorer (meme/quirk signal), and hosted
+  retrieval for X, YouTube, TikTok, Instagram, Polymarket, and grounded
+  Tavily web search.
+- **Public paths (no extra credentials)**: Reddit, Hacker News.
+- **GitHub** via the official API when `GH_TOKEN` or `GITHUB_TOKEN` is
+  set — optional.
+- **Fail-soft**: if one source errors or times out, the brief still
+  renders with the others and notes the gap.
 
-## Setup
+## Model Configuration
 
-- `AISA_API_KEY` is the main hosted credential.
-- `GH_TOKEN` or `GITHUB_TOKEN` is optional for GitHub search only.
-- Python `3.12+` is required.
+The skill makes three LLM calls per run. Each role is independently
+pinnable via `~/.config/last30days/.env`:
 
 ```bash
+LAST30DAYS_PLANNER_MODEL=qwen-flash           # fast + reliable JSON
+LAST30DAYS_RERANK_MODEL=qwen-plus-2025-12-01  # quality ranking
+LAST30DAYS_FUN_MODEL=qwen-flash               # cheap vibes
+```
+
+Or set `AISA_MODEL=...` for a single model across all three roles. Run
+`last30days setup` to pick interactively — the picker fetches the live
+catalog from [aisa.one/docs/guides/models](https://aisa.one/docs/guides/models).
+
+## Requirements
+
+- **Python 3.12+**
+- **`AISA_API_KEY`** — required. Get one at [aisa.one](https://aisa.one).
+- **`GH_TOKEN` / `GITHUB_TOKEN`** — optional, enables the GitHub source.
+
+```bash
+# Pin an interpreter ≥ 3.12
 for py in /usr/local/python3.12/bin/python3.12 python3.14 python3.13 python3.12 python3; do
   command -v "$py" >/dev/null 2>&1 || continue
   "$py" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || continue
@@ -59,27 +137,3 @@ for py in /usr/local/python3.12/bin/python3.12 python3.14 python3.13 python3.12 
   break
 done
 ```
-
-## Quick Reference
-
-```bash
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --emit=compact
-"${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" "$ARGUMENTS" --emit=json
-"${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" "$ARGUMENTS" --quick
-"${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" "$ARGUMENTS" --deep
-"${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" "$ARGUMENTS" --search=reddit,x,grounding
-"${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" --diagnose
-```
-
-## Inputs And Outputs
-
-- Input: a topic or comparison query such as `OpenAI Agents SDK`, `OpenClaw vs Codex`, or `Peter Steinberger`.
-- Output: synthesized research plus `provider_runtime`, `query_plan`, `ranked_candidates`, `clusters`, and `items_by_source`.
-
-## Example Queries
-
-- `last30days OpenAI Agents SDK`
-- `last30days Peter Steinberger`
-- `last30days OpenClaw vs Codex`
-- `last30days Kanye West --quick`
-


### PR DESCRIPTION
README: dropped the 'English ClawHub publish bundle' boilerplate (which doesn't belong in a user-facing README) and replaced with a proper quick- start, usage examples, flags table, and per-role model config notes.

SKILL.md: reformatted frontmatter to match the canonical sibling skills (marketpulse, media-gen, multi-source-search, perplexity-search, etc):
- Compact inline-JSON metadata under the 'aisa' namespace (was verbose YAML under 'openclaw')
- homepage: https://aisa.one (was https://github.com/AIsa-team/agent-skills)
- Added compatibility: openclaw, claude-code, hermes
- Dropped per-skill fields no sibling uses: version, argument-hint, allowed-tools, repository, author, license, user-invocable, files
- Body now leads with 'What Can You Do' example queries (matches marketpulse, media-gen pattern) before the reference material.