### PR TITLE
docs: refresh top-level README against current repo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,120 @@
 # AIsa Agent Skills ⚡
 
-> **Production-ready skills for autonomous agents. Compatible with all major agent harnesses, including OpenClaw, Claude Code, and Hermes.**
+> **Production-ready skills for autonomous agents.** Compatible with any
+> [agentskills.io](https://agentskills.io) harness — Claude Code, Claude,
+> OpenAI Codex, Cursor, Gemini CLI, OpenCode, Goose, OpenClaw, Hermes,
+> and others that implement the [Agent Skills specification](https://agentskills.io/specification).
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ---
 
-## What is This?
+## What is this?
 
-This repository contains **production-ready skills** for autonomous agents powered by [AIsa](https://aisa.one). Each skill provides a specific capability that your agent can use, and is compatible with all major agent harnesses — including OpenClaw, Claude Code, and Hermes.
-
----
-
-### Available Skills
-
-| Skill | Description | Status |
-|-------|-------------|--------|
-| [**MarketPulse**](./marketpulse/) | Query real-time and historical financial data across equities and crypto. | ✅ Ready |
-| [**Media Gen**](./media-gen/) | Generate images & videos with AIsa. | ✅ Ready |
-| [**Perplexity Search**](./perplexity-search/) | Perplexity Sonar search and answer generation through AIsa. | ✅ Ready |
-| [**Prediction Market Data**](./prediction-market-data/) | Prediction markets data - Polymarket, Kalshi markets, prices, positions, and trades. | ✅ Ready |
-| [**Prediction Market Arbitrage**](./prediction-market-arbitrage/) | Find and analyze arbitrage opportunities across prediction markets. | ✅ Ready |
-| [**Multi-source Search**](./multi-source-search/) | Multi-source intelligent search for agents. Retrieval across web, scholar, Tavily, and Perplexity Sonar models. | ✅ Ready |
-| [**Twitter**](./twitter/) | Searches and reads X (Twitter): profiles, timelines, mentions, followers, tweet search, trends, lists, communities, and Spaces. | ✅ Ready |
-| [**YouTube SERP**](./youtube-serp/) | Search YouTube videos, channels, and trends. | ✅ Ready |
+A catalog of agent skills powered by the [AIsa](https://aisa.one) unified
+API gateway. Each top-level directory is one self-contained skill — a
+bundle of `SKILL.md`, `README.md`, and supporting scripts that any
+skills-compatible harness can consume. One `AISA_API_KEY` covers them
+all.
 
 ---
 
-## Quick Start
+## Available skills
 
-### 1. Choose a Skill
+| Skill | What it does |
+|---|---|
+| [**last30days**](./last30days/) 📰 | 30-day multi-source research brief across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web. Returns a ranked, clustered brief with citations. |
+| [**MarketPulse**](./marketpulse/) 📊 | Real-time and historical equity data — prices, news, financial statements, analyst estimates, insider/institutional activity, SEC filings, earnings press releases, stock screening, macro interest rates. |
+| [**Media Gen**](./media-gen/) 🎬 | Generate images and videos. 4 image models across 3 endpoints (Gemini, Wan 2.7 image/pro, Seedream) and 4 Wan video variants (wan2.6/2.7 × t2v/i2v). |
+| [**Multi-source Search**](./multi-source-search/) 🔎 | Unified web + scholar + Tavily + Perplexity Sonar retrieval. Ranked results, content extraction, recursive crawling, site mapping. |
+| [**Perplexity Search**](./perplexity-search/) 🔎 | Perplexity Sonar family — fast answers, pro synthesis, chain-of-thought reasoning, deep research reports — all through AIsa. |
+| [**Prediction Market Arbitrage**](./prediction-market-arbitrage/) ⚖️ | Cross-platform arbitrage detection. Match events across Polymarket and Kalshi, compare implied probabilities, verify orderbook depth. |
+| [**Prediction Market Data**](./prediction-market-data/) 📈 | Unified access to Polymarket and Kalshi — market discovery, pricing, orderbooks, trade history, wallet positions, P&L. |
+| [**Twitter Autopilot**](./twitter-autopilot/) 🐦 | Full X/Twitter intelligence — profiles, timelines, mentions, search, trends, lists, communities, Spaces. OAuth-gated write for posting, liking, following. |
+| [**YouTube SERP**](./youtube-serp/) 📺 | YouTube search with ranked results and rich metadata. Content-gap analysis, competitor tracking, keyword research. |
 
-Browse the skills above and pick what your agent needs.
+---
 
-### 2. Follow the Skill Guide
+## Quick start
 
-Each skill folder contains:
-- `README.md` - Human-readable documentation
-- `SKILL.md` - Skill specification
-- Supporting scripts and references
-
-### 3. Configure Your Agent
+### 1. Get an AIsa API key
 
 ```bash
-# Example: Set your AIsa API key
-export AISA_API_KEY="your-api-key"
+export AISA_API_KEY="sk-..."
 ```
+
+Get one at [aisa.one](https://aisa.one).
+
+### 2. Pick a skill and invoke it
+
+Each skill lives in its own directory and carries a `SKILL.md`
+(agent-facing spec) and a `README.md` (human-facing overview). The
+harness auto-discovers `SKILL.md`; humans can skim the README.
+
+For example, to run `last30days` directly from the command line:
+
+```bash
+bash last30days/scripts/run-last30days.sh "OpenAI Agents SDK"
+```
+
+See each skill's README for per-skill usage.
 
 ---
 
-## Adding New Skills
+## Compatibility
 
-Want to contribute a skill? Each skill should include:
+Every skill in this repo works with any
+[agentskills.io](https://agentskills.io)-compatible harness, including:
 
-1. **SKILL.md** - Skill specification with metadata
-2. **README.md** - Human-readable documentation
-3. **Scripts/Tools** - Any supporting code
-4. **References** - API docs, examples
+- **Claude Code** and **Claude** (Anthropic)
+- **OpenAI Codex**
+- **Cursor**
+- **Gemini CLI** (Google)
+- **OpenCode**, **Goose**, **OpenClaw**, **Hermes**
+- and any other harness that implements the
+  [Agent Skills specification](https://agentskills.io/specification)
 
-See existing skills in this repository for reference.
+Requires Python 3, a POSIX shell, and `AISA_API_KEY`. Individual skills
+may require additional environment variables — check each skill's
+`SKILL.md`.
+
+---
+
+## Contributing a skill
+
+1. Read [`SKILL_AUTHORING.md`](./SKILL_AUTHORING.md) — the house SOP for
+   composing skills in this repo. It covers directory layout, required
+   frontmatter fields, body structure, canonical documentation links,
+   and the pre-PR validation checklist.
+2. Create a new top-level `<skill-name>/` directory following the SOP.
+3. Open a PR. Every skill must include:
+   - `SKILL.md` — agent-facing contract (frontmatter + instructions)
+   - `README.md` — human-facing overview
+   - A `## Compatibility` section listing supported harnesses
+   - A `## API Reference` section pointing to `aisa.one/docs/api-reference`
+
+See existing skills in this repo for reference. The
+[agentskills.io specification](https://agentskills.io/specification) is
+the authoritative source for the `SKILL.md` format.
 
 ---
 
 ## Links
 
-- ⚡ [AIsa](https://aisa.one) - Unified API backend
-- 📖 [Documentation](https://aisa.one/docs) - API reference
+- ⚡ [AIsa](https://aisa.one) — unified API gateway
+- 📖 [Documentation](https://aisa.one/docs) — guides, models, API reference
+- 🧭 [Agent Skills spec](https://agentskills.io/specification) — upstream format
+- 📋 [`SKILL_AUTHORING.md`](./SKILL_AUTHORING.md) — house authoring SOP
+- 🤖 [`CLAUDE.md`](./CLAUDE.md) — Claude Code's guide to this repo
 
 ---
 
 ## License
 
-Apache 2.0 License - see [LICENSE](LICENSE) for details.
+Apache 2.0 — see [LICENSE](LICENSE).
 
 ---
 
 <p align="center">
-  <b>AIsa Agent Skills</b> - Extend your agent's capabilities.
+  <b>AIsa Agent Skills</b> — extend your agent's capabilities.
 </p>


### PR DESCRIPTION
## Summary

Brings the repo-root `README.md` in line with the state of the repo after the SOP pass (#30) and subsequent cleanups (#32).

## Fixes

- **Adds the missing `last30days/` row** (merged via #28, was never added to the skills table)
- **Fixes the broken Twitter link** — the table linked `./twitter/` but the directory is `./twitter-autopilot/`
- **MarketPulse description**: dropped the stale "and crypto" claim (the skill covers equities + macro interest rates, not crypto)
- **Media Gen description**: now notes the full 4-image + 4-video roster
- **Compatibility tagline**: "OpenClaw, Claude Code, Hermes" → full agentskills.io roster (9 harnesses), matching the SOP

## Additions

- A dedicated `## Compatibility` section listing all 9 supported harnesses (mirrors the block every skill README now carries)
- Links to `SKILL_AUTHORING.md` and `CLAUDE.md`
- "Contributing a skill" checklist points to the SOP and spells out the mandatory `## Compatibility` and `## API Reference` sections

## Preserved

- Apache-2.0 license badge
- Overall structure (header → What is this → Skills → Quick Start → Links → License)
- Center-aligned footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
