### PR TITLE
fix(last30days): 4 bugs found in post-refactor audit

### DIFF
--- a/last30days/scripts/lib/github.py
+++ b/last30days/scripts/lib/github.py
@@ -91,14 +91,24 @@ def _parse_repo_from_url(html_url: str) -> str:
     return ""
 
 
+_DATE_YMD_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
 def _parse_date(iso_str: Optional[str]) -> Optional[str]:
-    """Extract YYYY-MM-DD from ISO 8601 datetime string."""
-    if not iso_str:
+    """Extract YYYY-MM-DD from an ISO 8601 datetime string.
+
+    Returns None if the input isn't a valid ISO-8601 prefix. The old
+    implementation did `iso_str[:10]` wrapped in try/except for
+    (IndexError, TypeError) — but string slicing never raises either,
+    so garbage like "bad" or "2026" would pass through unchanged and
+    then fall out of the date-range filter via lexicographic quirks.
+    """
+    if not isinstance(iso_str, str) or len(iso_str) < 10:
         return None
-    try:
-        return iso_str[:10]
-    except (IndexError, TypeError):
+    candidate = iso_str[:10]
+    if not _DATE_YMD_RE.match(candidate):
         return None
+    return candidate
 
 
 def _compute_relevance(

--- a/last30days/scripts/lib/planner.py
+++ b/last30days/scripts/lib/planner.py
@@ -185,11 +185,17 @@ def _sanitize_plan(
         source for source in available_sources
         if (not requested or source in requested)
     ]
-    source_weights = {
-        source: float(weight)
-        for source, weight in (raw.get("source_weights") or {}).items()
-        if source in available
-    }
+    # Coerce weights per-entry. A single bad value (non-numeric string,
+    # None, etc.) from the LLM should not tank the whole plan — skip
+    # the malformed entry and keep the good ones.
+    source_weights: dict[str, float] = {}
+    for source, weight in (raw.get("source_weights") or {}).items():
+        if source not in available:
+            continue
+        try:
+            source_weights[source] = float(weight)
+        except (TypeError, ValueError):
+            continue
     if requested:
         source_weights = {source: weight for source, weight in source_weights.items() if source in requested}
     if not source_weights:
@@ -218,13 +224,18 @@ def _sanitize_plan(
         ranking_query = str(subquery.get("ranking_query") or "").strip()
         if not search_query or not ranking_query:
             continue
+        # A bad weight on this one subquery shouldn't drop the whole plan.
+        try:
+            weight = max(0.05, float(subquery.get("weight") or 1.0))
+        except (TypeError, ValueError):
+            weight = 1.0
         subqueries.append(
             schema.SubQuery(
                 label=str(subquery.get("label") or f"q{index}").strip() or f"q{index}",
                 search_query=search_query,
                 ranking_query=ranking_query,
                 sources=sources,
-                weight=max(0.05, float(subquery.get("weight") or 1.0)),
+                weight=weight,
             )
         )
     if depth == "quick" and subqueries:

--- a/last30days/scripts/lib/providers.py
+++ b/last30days/scripts/lib/providers.py
@@ -109,7 +109,15 @@ def _resolve_model_pins(config: dict[str, Any], depth: str, provider_name: str) 
 
 
 def mock_runtime(config: dict[str, Any], depth: str) -> schema.ProviderRuntime:
-    """Resolve model pins for mock mode without requiring live credentials."""
+    """Build a ProviderRuntime for mock mode — no live credentials required.
+
+    Mock mode bypasses the model-pin requirement: it exists precisely for
+    running the pipeline offline with deterministic fixtures, so demanding
+    a real model pin would defeat the purpose. Env-var pins are still
+    honored if the installer has them set (useful for tests that want
+    to exercise per-role fallbacks), but their absence is fine.
+    """
+    del depth
     provider_name = (config.get("LAST30DAYS_REASONING_PROVIDER") or "aisa").lower()
     warn_if_legacy_provider_alias(provider_name)
     if provider_name == "auto":
@@ -117,7 +125,14 @@ def mock_runtime(config: dict[str, Any], depth: str) -> schema.ProviderRuntime:
     provider_name = _normalize_provider_name(provider_name)
     if provider_name != "aisa":
         raise RuntimeError(f"Unsupported reasoning provider: {provider_name}")
-    planner_model, rerank_model, fun_model = _resolve_model_pins(config, depth, provider_name)
+
+    # Synthesize model names for the mock runtime. Real models aren't
+    # called in mock mode; these strings are only surfaced in the
+    # provider_runtime block of the rendered report.
+    shared = config.get("AISA_MODEL")
+    planner_model = config.get("LAST30DAYS_PLANNER_MODEL") or shared or "mock-planner"
+    rerank_model = config.get("LAST30DAYS_RERANK_MODEL") or shared or "mock-rerank"
+    fun_model = config.get("LAST30DAYS_FUN_MODEL") or rerank_model or "mock-fun"
     return schema.ProviderRuntime(
         reasoning_provider=provider_name,
         planner_model=planner_model,

--- a/last30days/scripts/lib/rerank.py
+++ b/last30days/scripts/lib/rerank.py
@@ -158,8 +158,15 @@ def _apply_llm_scores(candidates: list[schema.Candidate], payload: dict) -> None
         candidate_id = str(row.get("candidate_id") or "").strip()
         if not candidate_id:
             continue
+        # One malformed row (e.g. `relevance: "high"` from a loose LLM)
+        # should not abort the whole batch. Skip this row; the candidate
+        # will fall back to its local score via `scores.get(…, …)` below.
+        try:
+            relevance = max(0.0, min(100.0, float(row.get("relevance") or 0.0)))
+        except (TypeError, ValueError):
+            continue
         scores[candidate_id] = (
-            max(0.0, min(100.0, float(row.get("relevance") or 0.0))),
+            relevance,
             str(row.get("reason") or "").strip() or None,
         )
     for candidate in candidates:
@@ -276,8 +283,15 @@ def _apply_fun_scores(candidates: list[schema.Candidate], payload: dict) -> None
         cid = str(row.get("candidate_id") or "").strip()
         if not cid:
             continue
+        # Per-row try/except: one malformed fun value shouldn't kill the
+        # whole batch. Affected candidate falls back to its heuristic
+        # score via `_apply_single_fun_fallback` in the loop below.
+        try:
+            fun = max(0.0, min(100.0, float(row.get("fun") or 0.0)))
+        except (TypeError, ValueError):
+            continue
         scores[cid] = (
-            max(0.0, min(100.0, float(row.get("fun") or 0.0))),
+            fun,
             str(row.get("reason") or "").strip() or None,
         )
     for c in candidates:


### PR DESCRIPTION
Four bugs found in a post-refactor audit (detailed findings in the commit message).

## Severity

| # | Bug | Class | Ship-status |
|---|---|---|---|
| 1 | `--mock` regression | My refactor introduced this | 100% reproducible — `--mock` aborts on any fresh install |
| 2 | `github._parse_date` silently passes garbage | Upstream bug class (same in v3.0.1) | Rare in practice, silent when it hits |
| 3 | `planner._sanitize_plan` aborts on one bad LLM weight | Upstream bug class | Moderate — depends on planner model's JSON discipline |
| 4 | `rerank._apply_llm_scores` aborts on one bad row | Upstream bug class | Moderate — same risk profile |

## Common root cause for bugs 2-4

Fictional or overscoped error handling:

- `try: iso_str[:10] except (IndexError, TypeError)` — slicing never raises either
- `float(v)` inside a dict comprehension / for-loop — one bad value tanks the whole structure

Fix pattern: **per-row try/except** instead of per-batch. Affected rows fall through to existing fallback paths; the good rows survive.

## End-to-end verification

Full pipeline at default depth after all four fixes:

```
total: 37.3s
sources: 7/8 populated — grounding=9, hackernews=3, instagram=20,
         reddit=14, tiktok=16, x=21, youtube=19
candidates: 40   clusters: 40
errors: (none)
LLM fallbacks: none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
