### PR TITLE
last30days: dedup SKILL.md and README.md

### DIFF
--- a/last30days/README.md
+++ b/last30days/README.md
@@ -38,29 +38,6 @@ others that implement the
 
 Requires Python 3, a POSIX shell, and `AISA_API_KEY`.
 
-## Quick start
-
-```bash
-# 1. Set your AIsa key
-export AISA_API_KEY=sk-...
-
-# 2. First-run setup (interactive model picker)
-bash scripts/run-last30days.sh setup
-
-# 3. Research a topic
-bash scripts/run-last30days.sh "OpenAI Agents SDK"
-```
-
-## Examples
-
-```bash
-last30days "OpenAI Agents SDK"
-last30days "Claude Code vs Codex"
-last30days "Peter Steinberger"
-last30days "bitcoin price" --quick
-last30days "Perplexity" --emit=json
-```
-
 ## What it returns
 
 A single markdown (or JSON) brief:

--- a/last30days/SKILL.md
+++ b/last30days/SKILL.md
@@ -2,16 +2,12 @@
 name: last30days
 description: "Research the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web search. Returns a ranked, clustered brief with citations. Use when the task needs recent social evidence, competitor comparisons, launch reactions, trend scans, or person/company profiles."
 homepage: https://aisa.one
-metadata: {"aisa":{"emoji":"📰","requires":{"bins":["python3","bash"],"env":["AISA_API_KEY"]},"primaryEnv":"AISA_API_KEY","compatibility":["openclaw","claude-code","hermes"]}}
 license: MIT
 compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
 metadata: {"aisa": {"emoji": "📰", "homepage": "https://aisa.one", "requires": {"bins": ["python3", "bash"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
 ---
 # last30days 📰
 
-# last30days 📰
-
-**30-day multi-source research brief for autonomous agents. Powered by AIsa.**
 **30-day multi-source research brief for autonomous agents. Powered by AIsa.**
 
 One API key. Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web — merged into a single ranked brief.
@@ -105,86 +101,6 @@ bash {baseDir}/scripts/run-last30days.sh --diagnose
 - `provider_runtime` — which models + retrieval backends ran
 - `errors_by_source` — any source-level failures (fail-soft)
 
-One API key. Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web — merged into a single ranked brief.
-
-## What Can You Do?
-- You need last-30-days evidence on a person, company, product, market, tool, or trend.
-- You want a ranked competitor comparison, launch-reaction summary, creator/community sentiment scan, or shipping update.
-- You want a structured JSON brief to feed into another agent.
-
-### Trend scan
-```text
-"last30days OpenAI Agents SDK"
-```
-
-### Competitor comparison
-```text
-"last30days Claude Code vs Codex"
-```
-- Timeless reference questions with no recent-evidence requirement.
-- When you only want one official source and don't want social/community signals.
-
-### Person / company profile
-```text
-"last30days Peter Steinberger"
-```
-
-### Launch reaction
-```text
-"last30days GPT-5 launch --deep"
-```
-
-### Prediction-market angle
-```text
-"last30days bitcoin price"
-```
-
-## Quick Start
-
-```bash
-# 1. Export your AIsa key
-export AISA_API_KEY=sk-...
-
-# 2. First-run setup (interactive — picks planner / rerank / fun-scorer models)
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" setup
-
-# 3. Research a topic
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "OpenAI Agents SDK"
-```
-
-## Common Flags
-
-```bash
-# Low-latency profile (fewer candidates per source)
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --quick
-
-# Higher-recall profile
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --deep
-
-# Machine-readable output (full plan + candidates + clusters)
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --emit=json
-
-# Restrict to specific sources
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" "$ARGUMENTS" --search=reddit,x,grounding
-
-# Check provider / source availability
-bash "${SKILL_ROOT}/scripts/run-last30days.sh" --diagnose
-```
-
-## Inputs and Outputs
-
-**Input.** A topic, person, company, product, or comparison — e.g.
-`OpenAI Agents SDK`, `OpenClaw vs Codex`, `Peter Steinberger`.
-
-**Output.** A markdown brief (default) or JSON with:
-
-- `query_plan` — planner-generated subqueries and source weights
-- `ranked_candidates` — reranked candidate pool with scores
-- `clusters` — semantically grouped findings
-- `items_by_source` — per-source item lists with dates, engagement, URLs
-- `provider_runtime` — which models + retrieval backends ran
-- `errors_by_source` — any source-level failures (fail-soft)
-
 ## When to use
 
 - You need last-30-days evidence on a person, company, product, market, tool, or trend.
@@ -197,33 +113,6 @@ bash "${SKILL_ROOT}/scripts/run-last30days.sh" --diagnose
 - When you only want one official source and don't want social/community signals.
 
 ## Capabilities
-
-- **AISA-powered**: planner (structured JSON query plan), reranker
-  (relevance ordering), fun-scorer (meme/quirk signal), and hosted
-  retrieval for X, YouTube, TikTok, Instagram, Polymarket, and grounded
-  Tavily web search.
-- **Public paths (no extra credentials)**: Reddit, Hacker News.
-- **GitHub** via the official API when `GH_TOKEN` or `GITHUB_TOKEN` is
-  set — optional.
-- **Fail-soft**: if one source errors or times out, the brief still
-  renders with the others and notes the gap.
-
-## Model Configuration
-
-The skill makes three LLM calls per run. Each role is independently
-pinnable via `~/.config/last30days/.env`:
-
-```bash
-LAST30DAYS_PLANNER_MODEL=qwen-flash           # fast + reliable JSON
-LAST30DAYS_RERANK_MODEL=qwen-plus-2025-12-01  # quality ranking
-LAST30DAYS_FUN_MODEL=qwen-flash               # cheap vibes
-```
-
-Or set `AISA_MODEL=...` for a single model across all three roles. Run
-`last30days setup` to pick interactively — the picker fetches the live
-catalog from [aisa.one/docs/guides/models](https://aisa.one/docs/guides/models).
-
-## Requirements
 
 - **AISA-powered**: planner (structured JSON query plan), reranker
   (relevance ordering), fun-scorer (meme/quirk signal), and hosted


### PR DESCRIPTION
## Summary

- **SKILL.md**: removed 111 lines of template-merge duplication. Frontmatter had two `metadata:` keys; the body through "Inputs and Outputs" was repeated (second copy used `${SKILL_ROOT}` shell vars instead of the `{baseDir}` harness placeholder); Capabilities + Model Configuration were duplicated, with the Capabilities copy mis-headed as "Requirements" — shadowing the real Requirements section.
- **README.md**: removed 23 lines — Quick start and Examples blocks were repeated.

No canonical content removed — only duplicates. 134 lines deleted total.

## Test plan

- [ ] Render SKILL.md and confirm no section appears twice
- [ ] Verify frontmatter parses (single `metadata:` key)
- [ ] Confirm `{baseDir}` placeholder is used consistently in code blocks
- [ ] Confirm Requirements section correctly lists Python 3.12+ / AISA_API_KEY / GH_TOKEN (not the Capabilities bullets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)