### PR TITLE
Daniel/trend forecast

### DIFF
--- a/trend-forecast/.gitignore
+++ b/trend-forecast/.gitignore
@@ -1,4 +1,0 @@
-# Python bytecode
-__pycache__/
-*.py[cod]
-*$py.class

--- a/trend-forecast/.gitignore
+++ b/trend-forecast/.gitignore
@@ -1,0 +1,4 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class

--- a/trend-forecast/README.md
+++ b/trend-forecast/README.md
@@ -1,4 +1,4 @@
-# 📈 Trend Forecaster
+# 📈 Trend Forecast
 
 Multi-signal trend analysis for autonomous agents. Powered by [AIsa](https://aisa.one).
 

--- a/trend-forecast/README.md
+++ b/trend-forecast/README.md
@@ -1,0 +1,140 @@
+# 📈 Trend Forecaster
+
+Multi-signal trend analysis for autonomous agents. Powered by [AIsa](https://aisa.one).
+
+One API key → five data streams → confidence-scored forecasts.
+
+## What It Does
+
+Give it any question about a trend, and it:
+
+1. **Decomposes** your query into source-specific search terms (via LLM)
+2. **Queries prediction markets** for contract odds (Polymarket, Kalshi)
+3. **Searches Twitter/X** for social sentiment and discussion volume
+4. **Scans news** via Tavily for article velocity and headline sentiment
+5. **Pulls stock data** if a public company or financial instrument is involved
+6. **Synthesizes** all signals into a forecast with a confidence score (0-100)
+
+All through a single `AISA_API_KEY`. No juggling vendor accounts.
+
+## Install
+
+```bash
+# For OpenClaw
+npx clawhub@latest install trend-forecast
+
+# For Claude Code
+mkdir -p ~/.claude/skills
+cp -r trend-forecast ~/.claude/skills/
+
+# For Cursor / Codex
+mkdir -p ~/.cursor/skills
+cp -r trend-forecast ~/.cursor/skills/
+```
+
+## Setup
+
+```bash
+export AISA_API_KEY="your-key-here"
+# Get one at https://aisa.one
+```
+
+## Usage
+
+### As an agent skill
+
+Just ask naturally:
+
+- *"What's the outlook on the AI chip market?"*
+- *"Will the Fed cut rates before September?"*
+- *"Forecast Tesla based on current sentiment"*
+- *"What are prediction markets saying about the 2026 midterms?"*
+
+### As a CLI tool
+
+```bash
+# Markdown report (default)
+python3 scripts/trend_forecast.py "Will the Fed cut rates in 2026?"
+
+# JSON output
+python3 scripts/trend_forecast.py "Tesla outlook" --output json
+
+# Save to file
+python3 scripts/trend_forecast.py "AI market trends" --save report.md
+
+# Use a different synthesis model
+python3 scripts/trend_forecast.py "Bitcoin outlook" --model gpt-4.1
+```
+
+## Example Output
+
+```
+📈 TREND FORECAST: Fed rate cut increasingly likely by Q3 2026
+
+Direction: 🟢 BULLISH
+Confidence: 72/100
+Signal Agreement: high
+Time Horizon: 3-6 months
+Generated: 2026-05-21 14:30 UTC
+
+---
+
+## Analysis
+
+Prediction markets currently price a Fed rate cut before September 2026 at 72%,
+up from 58% two weeks ago. Twitter discussion volume around "rate cut" has
+increased 3x over the past week...
+
+## Key Signals
+
+- Polymarket prices Fed rate cut at 72% (up from 58%)
+- Twitter volume on "Fed rate cut" up 3x in 7 days
+- 23 major news articles in the last week, predominantly dovish framing
+- Bond ETFs (TLT, BND) up 2.1% over 5 days
+
+## Risks & Caveats
+
+- Inflation data release next week could shift sentiment rapidly
+- Prediction markets have historically overreacted to Fed commentary
+```
+
+## Project Structure
+
+```
+trend-forecast/
+├── SKILL.md                       # Skill definition (metadata + workflow)
+├── README.md                      # This file
+├── .gitignore                     # Ignores __pycache__/
+├── scripts/
+│   ├── aisa_client.py             # Reusable AIsa API client
+│   └── trend_forecast.py          # Main orchestrator script
+└── references/
+    └── api_endpoints.md           # AIsa endpoint documentation
+```
+
+## AIsa APIs Used
+
+| Data Source        | AIsa Endpoint                                       | Purpose                   |
+|--------------------|-----------------------------------------------------|---------------------------|
+| LLM Gateway        | `api.aisa.one/v1/chat/completions`                  | Query decomposition + synthesis (`gpt-4.1-mini`) |
+| Prediction Markets | `api.aisa.one/apis/v1/polymarket/markets` (+ `/kalshi/markets`) | Contract odds & volume    |
+| Twitter/X          | `api.aisa.one/apis/v1/twitter/tweet/advanced_search` | Social sentiment          |
+| Tavily (News)      | `api.aisa.one/apis/v1/tavily/search`                | News velocity & headlines |
+| MarketPulse        | `api.aisa.one/apis/v1/financial/*`                  | Prices, metrics & company news |
+
+See [`references/api_endpoints.md`](references/api_endpoints.md) for the full list of confirmed endpoints, parameters, and per-call pricing.
+
+## Contributing
+
+1. Fork this repo
+2. Create a feature branch
+3. Test with `python3 scripts/trend_forecast.py "test query"`
+4. Submit a PR to the [AIsa-team/agent-skills](https://github.com/AIsa-team/agent-skills) repo
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE)
+
+---
+
+*Built for [AIsa](https://aisa.one) · One key, every data source.*

--- a/trend-forecast/SKILL.md
+++ b/trend-forecast/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: trend-forecast
+description: >
+  Multi-signal trend forecasting for autonomous agents. Combines prediction market
+  odds, Twitter/X social sentiment, news velocity, and stock market data into a
+  unified trend analysis with confidence scoring. Powered by AIsa — one API key,
+  five data streams.
+version: 1.0.0
+triggers:
+  - "forecast trend"
+  - "predict what happens with"
+  - "trend analysis for"
+  - "what's the outlook on"
+  - "will X happen"
+  - "what are the odds of"
+  - "sentiment analysis on"
+  - "market outlook for"
+tools:
+  - bash
+  - read
+  - write
+metadata:
+  openclaw:
+    emoji: "📈"
+    requires:
+      bins:
+        - curl
+        - python3
+      env:
+        - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+---
+
+# Trend Forecast
+
+> Multi-signal trend analysis for autonomous agents. Powered by AIsa.
+> One API key. Five data streams. Confidence-scored forecasts.
+
+## Context
+
+You are a trend forecasting agent. When the user asks about a topic's trajectory,
+outlook, or probability, you gather signals from five independent data sources
+through AIsa's unified API, then synthesize a forecast with a confidence score.
+
+This skill is NOT a web search tool. It is a **multi-signal aggregation engine**
+that pulls structured data from prediction markets, social media, news, and
+financial markets — then uses an LLM to synthesize a trend report.
+
+All endpoints share one auth header: `Authorization: Bearer $AISA_API_KEY`.
+The REST surface lives under `https://api.aisa.one/apis/v1`; the OpenAI-compatible
+LLM gateway lives under `https://api.aisa.one/v1` (note: no `/apis`).
+
+## Example Prompts
+
+- "What's the outlook on the AI chip market over the next 6 months?"
+- "Will the Fed cut rates before September?"
+- "Forecast the trend for Tesla stock based on current sentiment"
+- "What are prediction markets saying about the 2026 midterms?"
+- "Trend analysis for remote work adoption — combine social, news, and market data"
+
+## Environment
+
+```bash
+export AISA_API_KEY="your-aisa-api-key"
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    USER QUERY                           │
+│          "What's the outlook on X?"                     │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│              QUERY DECOMPOSITION (LLM)                  │
+│  Break topic into search terms per data source          │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+          ┌────────────┼────────────┬────────────┐
+          ▼            ▼            ▼            ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │Prediction│ │ Twitter  │ │  News    │ │  Stock   │
+    │ Markets  │ │Sentiment │ │ Velocity │ │  Data    │
+    │ (odds)   │ │ (volume) │ │ (tavily) │ │(financial)│
+    └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘
+         │            │            │             │
+         └────────────┴─────┬──────┴─────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│              SIGNAL SYNTHESIS (LLM)                     │
+│  Weigh signals, detect agreement/conflict,              │
+│  produce confidence score (0-100) + forecast            │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Workflow
+
+Follow these steps in order. Each step calls a specific AIsa API endpoint.
+
+### Step 1: Decompose the Query
+
+Use the AIsa LLM gateway to break the user's query into source-specific search terms.
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You decompose a user query into search terms for 4 data sources. Respond ONLY with JSON: {\"prediction_market_query\": \"...\", \"twitter_query\": \"...\", \"news_query\": \"...\", \"stock_symbols\": [\"...\"], \"topic_summary\": \"...\"}. stock_symbols must be real tickers (AAPL, NVDA, TLT) — never institution abbreviations like FED/SEC/FDA."
+      },
+      {"role": "user", "content": "<USER_QUERY>"}
+    ],
+    "temperature": 0.2
+  }'
+```
+
+### Step 2: Gather Prediction Market Signals
+
+Prices come in **two steps**: first query `/markets` to find the market and its
+ID, then pass that ID to `/market-price/` to get the current odds. Prices are
+decimals 0–1 representing probability (`0.65` = 65%).
+
+```bash
+# 1. Find Polymarket markets (params: search, status, market_slug, limit)
+curl "https://api.aisa.one/apis/v1/polymarket/markets?search=<PREDICTION_MARKET_QUERY>&status=open&limit=5" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+
+# 2. Price a token (token_id = side_a.id or side_b.id from step 1)
+curl "https://api.aisa.one/apis/v1/polymarket/market-price/<TOKEN_ID>" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+For Kalshi, the flow is the same but keyed on `market_ticker`:
+
+```bash
+curl "https://api.aisa.one/apis/v1/kalshi/markets?search=<PREDICTION_MARKET_QUERY>&limit=5" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+
+curl "https://api.aisa.one/apis/v1/kalshi/market-price/<MARKET_TICKER>" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+Extract: market titles, current YES/NO prices (decimal probability), volume, and recency.
+
+### Step 3: Gather Twitter/X Social Sentiment
+
+Search Twitter for recent discussion volume and sentiment signals. The tweet
+search endpoint is `/twitter/tweet/advanced_search` with params `query` and
+`queryType` (`Latest` or `Top`).
+
+```bash
+curl "https://api.aisa.one/apis/v1/twitter/tweet/advanced_search?query=<TWITTER_QUERY>&queryType=Latest" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+Extract: tweet count, engagement metrics (likes, retweets, replies), notable accounts
+posting about the topic, and overall sentiment tone.
+
+### Step 4: Gather News Signals
+
+Use AIsa's Tavily relay to search recent news articles about the topic.
+
+```bash
+curl -X POST "https://api.aisa.one/apis/v1/tavily/search" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "<NEWS_QUERY>",
+    "search_depth": "advanced",
+    "max_results": 10,
+    "topic": "news",
+    "days": 7
+  }'
+```
+
+Extract: article count, source diversity, headline sentiment, publication velocity
+(are articles accelerating or decelerating?).
+
+### Step 5: Gather Stock/Market Signals (if applicable)
+
+If the topic relates to a publicly traded company, sector, or financial instrument,
+query AIsa's MarketPulse `/financial/` endpoints. Pull three signals per ticker:
+
+```bash
+# Historical prices (interval is required: day, week, month, etc.)
+curl "https://api.aisa.one/apis/v1/financial/prices?ticker=<STOCK_SYMBOL>&interval=day" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+
+# Real-time financial metrics snapshot
+curl "https://api.aisa.one/apis/v1/financial/financial-metrics/snapshot?ticker=<STOCK_SYMBOL>" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+
+# Company news
+curl "https://api.aisa.one/apis/v1/financial/news?ticker=<STOCK_SYMBOL>" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+Extract: recent price trend (1d, 5d, 30d), valuation/profitability metrics, and
+headline sentiment. For deeper signals, add `/financial/analyst-estimates`,
+`/financial/insider-trades`, or the macro `/financial/macro/interest-rates/snapshot`.
+
+Use only real ticker symbols (AAPL, NVDA, TLT) — never institution abbreviations
+like FED/SEC/FDA. If no stock symbols are relevant, skip this step and note
+"N/A — non-financial topic".
+
+### Step 6: Synthesize Forecast
+
+Pass all gathered signals to the AIsa LLM gateway for synthesis.
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a trend analyst. Given structured signals from prediction markets, Twitter, news, and stock data, produce a forecast. Output JSON: {\"trend_direction\": \"bullish|bearish|neutral|mixed\", \"confidence_score\": 0-100, \"time_horizon\": \"...\", \"headline\": \"...\", \"analysis\": \"...\", \"signal_agreement\": \"high|medium|low\", \"key_signals\": [...], \"risks\": [...], \"data_gaps\": [...]}"
+      },
+      {
+        "role": "user",
+        "content": "TOPIC: <TOPIC_SUMMARY>\n\nPREDICTION MARKETS:\n<PM_DATA>\n\nTWITTER SENTIMENT:\n<TWITTER_DATA>\n\nNEWS VELOCITY:\n<NEWS_DATA>\n\nMARKET DATA:\n<STOCK_DATA>"
+      }
+    ],
+    "temperature": 0.3
+  }'
+```
+
+### Step 7: Format and Deliver
+
+Present the forecast to the user in this format:
+
+```
+📈 TREND FORECAST: <headline>
+
+Direction: <trend_direction>
+Confidence: <confidence_score>/100
+Signal Agreement: <signal_agreement>
+Time Horizon: <time_horizon>
+
+ANALYSIS:
+<analysis paragraph>
+
+KEY SIGNALS:
+- <signal 1>
+- <signal 2>
+- <signal 3>
+
+RISKS & CAVEATS:
+- <risk 1>
+- <risk 2>
+
+DATA GAPS:
+- <any sources that returned no data>
+```
+
+## Rules
+
+- ALWAYS call at least 3 of the 4 data sources before synthesizing. A forecast
+  from fewer than 3 sources must include a prominent "LOW CONFIDENCE — limited
+  data sources" warning.
+- NEVER present prediction market odds as certainties. Always frame them as
+  "prediction markets currently price X at Y%" not "X will happen".
+- NEVER provide financial advice. Frame all output as informational analysis,
+  not investment recommendations. Include a disclaimer when stock data is involved.
+- For stock signals, use only real ticker symbols. Never pass institution
+  abbreviations (FED, SEC, FDA) to the `/financial/` endpoints — they will fail.
+- If the AISA_API_KEY is not set, prompt the user to set it and provide a link
+  to https://aisa.one to create an account.
+- If any API call fails, log the error, continue with remaining sources, and
+  note the gap in the final output.
+
+## Automation
+
+For recurring forecasts, use the Python script:
+
+```bash
+python3 scripts/trend_forecast.py "Will the Fed cut rates in 2026?" --output json
+python3 scripts/trend_forecast.py "Tesla outlook" --output markdown --save report.md
+python3 scripts/trend_forecast.py "Bitcoin outlook" --model gpt-4.1
+```
+
+See `scripts/trend_forecast.py` for the full implementation and `references/api_endpoints.md`
+for complete AIsa endpoint documentation.

--- a/trend-forecast/references/api_endpoints.md
+++ b/trend-forecast/references/api_endpoints.md
@@ -1,0 +1,212 @@
+# AIsa API Endpoints — Trend Forecaster
+
+Every endpoint the skill touches, documented from the actual calls in
+`scripts/aisa_client.py`.
+
+- **REST base URL:** `https://api.aisa.one/apis/v1`
+- **LLM base URL:** `https://api.aisa.one/v1` (OpenAI-compatible — note: **no** `/apis`)
+- **Auth header:** `Authorization: Bearer $AISA_API_KEY` on every request
+
+---
+
+## LLM Gateway (query decomposition + synthesis)
+
+OpenAI-compatible. Base URL is `https://api.aisa.one/v1`. The skill uses
+`gpt-4.1-mini` for both decomposition and synthesis (override with `--model`).
+
+| Method | Path                   | Purpose                          | Price/call |
+|--------|------------------------|----------------------------------|------------|
+| POST   | `/v1/chat/completions` | Standard OpenAI chat completions | ~$0.01–0.05 (model-dependent) |
+
+```bash
+curl -X POST "https://api.aisa.one/v1/chat/completions" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-4.1-mini", "messages": [...], "temperature": 0.3}'
+```
+
+Available models: `gpt-4.1`, `gpt-4.1-mini`, `claude-sonnet-4-20250514`,
+`gemini-2.5-flash`, `deepseek-r1`, `qwen-3`, and 70+ more.
+
+Client function: `llm_chat(messages, model="gpt-4.1-mini", temperature=0.3)`.
+
+---
+
+## MarketPulse — Stock / Financial Data (20 endpoints)
+
+All under `/financial/`. Prices ~$0.001/call, financials ~$0.002/call,
+macro ~$0.0005/call.
+
+| Method | Path                                            | Purpose                                              |
+|--------|-------------------------------------------------|------------------------------------------------------|
+| GET    | `/financial/prices`                             | Historical stock prices (requires `interval`, e.g. `?ticker=AAPL&interval=day`) |
+| GET    | `/financial/news`                               | Company news by ticker (`?ticker=AAPL`)              |
+| GET    | `/financial/financials`                         | All financial statements (requires `period`, e.g. `?ticker=AAPL&period=annual`) |
+| GET    | `/financial/financials/income-statements`       | Income statements (requires `period`)                |
+| GET    | `/financial/financials/balance-sheets`          | Balance sheets (requires `period`)                   |
+| GET    | `/financial/financials/cash-flow-statements`    | Cash flow statements (requires `period`)             |
+| GET    | `/financial/financials/segmented-revenues`      | Revenue by segment and geography (requires `period`) |
+| GET    | `/financial/financial-metrics/snapshot`         | Real-time financial metrics (`?ticker=AAPL`)         |
+| GET    | `/financial/financial-metrics`                  | Historical metrics (requires `period`)               |
+| GET    | `/financial/analyst-estimates`                  | EPS estimates (`?ticker=AAPL`)                       |
+| GET    | `/financial/earnings/press-releases`            | Earnings press releases (~2,776 supported tickers)   |
+| GET    | `/financial/insider-trades`                     | Insider trades (`?ticker=AAPL`)                      |
+| GET    | `/financial/institutional-ownership`            | Institutional ownership (by ticker or investor)      |
+| GET    | `/financial/filings`                            | SEC filings (`?ticker=AAPL`)                         |
+| GET    | `/financial/filings/items`                      | SEC filing items (requires `filing_type` and `year`) |
+| GET    | `/financial/company/facts`                      | Company facts (by ticker or CIK)                     |
+| POST   | `/financial/financials/search/screener`         | Stock screener                                       |
+| POST   | `/financial/financials/search/line-items`       | Search specific line items across tickers            |
+| GET    | `/financial/macro/interest-rates/snapshot`      | Current interest rates                               |
+| GET    | `/financial/macro/interest-rates`               | Historical rates                                     |
+
+Client functions: `get_stock_prices`, `get_stock_news`, `get_financial_metrics`,
+`get_analyst_estimates`, `get_insider_trades`, `get_interest_rates`. The
+orchestrator pulls prices + metrics + news per ticker.
+
+```bash
+curl "https://api.aisa.one/apis/v1/financial/prices?ticker=AAPL&interval=day" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+> Use only real ticker symbols. Institution abbreviations (FED, SEC, FDA) are not
+> tickers and will fail — for Fed topics use rate-sensitive ETFs like TLT/BND or
+> financials like JPM/GS.
+
+---
+
+## Prediction Markets — Polymarket + Kalshi (16 endpoints)
+
+All $0.010/call. Prices are decimals (`0.65` = 65% probability). The Yes price
+is the probability the market thinks the event will happen.
+
+**Two-step price lookup:** to get a price you must first query `/markets` to find
+the market and its ID, then pass that ID to `/market-price/`. Polymarket uses
+`token_id` (from `side_a.id` or `side_b.id` in the markets response); Kalshi uses
+`market_ticker` (from the markets response).
+
+| Method | Path                                            | Key params                              | Purpose                                                   |
+|--------|-------------------------------------------------|-----------------------------------------|-----------------------------------------------------------|
+| GET    | `/polymarket/markets`                           | `search`, `status`, `market_slug`, `limit` | List markets with fuzzy search                            |
+| GET    | `/polymarket/market-price/{token_id}`           | `token_id`, `at_time`                   | Current/historical market price (probability 0–1)         |
+| GET    | `/polymarket/events`                            | tags, status                            | Grouped related markets ordered by volume                 |
+| GET    | `/polymarket/orderbooks`                        | market, condition, token                | Historical orderbook snapshots (bids, asks, metadata)     |
+| GET    | `/polymarket/orders`                            | market, condition, token, time, wallet  | Historical trade data                                     |
+| GET    | `/polymarket/activity`                          | wallet                                  | On-chain trading activity (MERGES, SPLITS, REDEEMS)       |
+| GET    | `/polymarket/candlesticks/{condition_id}`       | `condition_id`                          | OHLC candlestick data with volume, open interest          |
+| GET    | `/polymarket/positions/wallet/{wallet_address}` | `wallet_address`                        | Active positions for a proxy wallet                       |
+| GET    | `/polymarket/wallet`                            | EOA, proxy, handle                      | Wallet info by EOA, proxy, or handle                      |
+| GET    | `/polymarket/wallet/pnl/{wallet_address}`       | `wallet_address`                        | Realized PnL over time                                    |
+| GET    | `/kalshi/markets`                               | `search`, `status`, `market_ticker`     | List Kalshi markets with fuzzy search                     |
+| GET    | `/kalshi/market-price/{market_ticker}`          | `market_ticker`, `at_time`              | Current/historical yes/no pricing                         |
+| GET    | `/kalshi/orderbooks`                            | market                                  | Historical orderbook snapshots                            |
+| GET    | `/kalshi/trades`                                | market                                  | Executed trade history                                    |
+| GET    | `/matching-markets/sports`                      | —                                       | Find equivalent markets across platforms                  |
+| GET    | `/matching-markets/sports/{sport}`              | `sport`, date                           | Cross-platform sports markets by date                     |
+
+Client functions: `search_prediction_markets` + `get_polymarket_price`
+(Polymarket), `search_kalshi_markets` + `get_kalshi_price` (Kalshi).
+
+```bash
+# 1. Find the market
+curl "https://api.aisa.one/apis/v1/polymarket/markets?search=Fed%20rate%20cut&status=open&limit=5" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+
+# 2. Price the token (token_id = side_a.id / side_b.id from step 1)
+curl "https://api.aisa.one/apis/v1/polymarket/market-price/<TOKEN_ID>" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+---
+
+## Twitter / X (social sentiment)
+
+| Method | Path                                       | Purpose                            |
+|--------|--------------------------------------------|------------------------------------|
+| GET    | `/twitter/tweet/advanced_search`           | Search tweets (`?query=...&queryType=Latest`, `Latest`\|`Top`) |
+| GET    | `/twitter/trends`                          | Trending topics (`?woeid=1` = worldwide) |
+| GET    | `/twitter/user/info`                       | User profile info (`?userName=...`) |
+| GET    | `/twitter/user/last_tweets`                | User's recent tweets (`?userName=...`) |
+| GET    | `/twitter/user/mentions`                   | User mentions (`?userName=...`)    |
+| GET    | `/twitter/user/followers`                  | Follower list (`?userName=...`)    |
+| GET    | `/twitter/user/followings`                 | Following list (`?userName=...`)   |
+| GET    | `/twitter/user/batch_info_by_ids`          | Batch user info by IDs (`?userIds=...`) |
+| GET    | `/twitter/user/search`                     | Search for users by keyword (`?query=...`) |
+
+Client function: `search_twitter` (uses `/twitter/tweet/advanced_search`). Tweet
+search params are `query` and `queryType` (`Latest`|`Top`) — there is no
+`/twitter/search` endpoint or `search_type` param. Pricing varies by AIsa plan;
+treat as ~$0.01/call for budgeting.
+
+```bash
+curl "https://api.aisa.one/apis/v1/twitter/tweet/advanced_search?query=Fed%20rate%20cut&queryType=Latest" \
+  -H "Authorization: Bearer $AISA_API_KEY"
+```
+
+---
+
+## Tavily — News / Web Search
+
+| Method | Path             | Purpose                    | Price/call |
+|--------|------------------|----------------------------|------------|
+| POST   | `/tavily/search` | AI-optimized web search    | ~$0.01     |
+
+Body fields: `query` (string), `search_depth` (`basic`|`advanced`),
+`max_results` (5–20), `topic` (`general`|`news`), `days` (e.g. `7`).
+
+Client function: `search_news`.
+
+```bash
+curl -X POST "https://api.aisa.one/apis/v1/tavily/search" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Fed rate cut", "search_depth": "advanced", "max_results": 10, "topic": "news", "days": 7}'
+```
+
+---
+
+## Perplexity (supplemental deep research)
+
+| Method | Path                  | Purpose                                |
+|--------|-----------------------|----------------------------------------|
+| POST   | `/perplexity/search`  | Deep research via Perplexity Sonar     |
+
+Body: `{"query": "..."}`. Client function: `perplexity_search`.
+
+```bash
+curl -X POST "https://api.aisa.one/apis/v1/perplexity/search" \
+  -H "Authorization: Bearer $AISA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "outlook for AI chip demand 2026"}'
+```
+
+---
+
+## Scholar / Web Search (supplemental)
+
+| Method | Path                     | Purpose                                  |
+|--------|--------------------------|------------------------------------------|
+| POST   | `/scholar/search/web`    | Web search (`?query=...&max_num_results=10`) |
+| POST   | `/scholar/search/smart`  | Smart hybrid search (`?query=...&max_num_results=10`) |
+| POST   | `/scholar/search/scholar`| Academic search (`?query=...&max_num_results=10`) |
+| POST   | `/scholar/explain`       | Confidence-scored explanation of results |
+
+`/scholar/explain` body: `{"results": [...], "language": "en", "format": "summary"}`.
+Not wired into the default orchestrator — available for deeper manual research.
+
+---
+
+## Per-forecast cost estimate
+
+A typical forecast (decompose + 3–4 sources + synthesis) costs roughly:
+
+- LLM calls (2× `gpt-4.1-mini`): ~$0.01–0.02
+- Prediction markets: ~$0.01–0.02 (markets list + optional price lookups)
+- Twitter search: ~$0.01
+- Tavily news: ~$0.01
+- Stock data (per ticker: prices + metrics + news): ~$0.003
+- **Total: ~$0.05–0.08 per forecast**
+
+Every response includes `usage.cost` and `usage.credits_remaining`. See
+<https://aisa.one/docs/api-reference> for the full catalog and
+<https://aisa.one/docs/guides/pricing> for current per-call pricing.

--- a/trend-forecast/scripts/aisa_client.py
+++ b/trend-forecast/scripts/aisa_client.py
@@ -1,0 +1,248 @@
+"""
+AIsa API Client for Trend Forecaster
+Handles all AIsa endpoint calls with error handling and retry logic.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+import urllib.parse
+import time
+
+AISA_BASE = "https://api.aisa.one"
+AISA_API_BASE = f"{AISA_BASE}/apis/v1"
+AISA_LLM_BASE = f"{AISA_BASE}/v1"
+
+
+def get_api_key():
+    """Get AISA_API_KEY from environment."""
+    key = os.environ.get("AISA_API_KEY")
+    if not key:
+        print("ERROR: AISA_API_KEY not set.", file=sys.stderr)
+        print("Get your key at https://aisa.one", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def _request(url, method="GET", data=None, retries=2):
+    """Make an authenticated request to AIsa API."""
+    api_key = get_api_key()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read().decode("utf-8")
+                return json.loads(raw) if raw.strip() else {}
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8", errors="replace")
+            if e.code == 429 and attempt < retries:
+                wait = 2 ** (attempt + 1)
+                print(f"  Rate limited, retrying in {wait}s...", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print(f"  HTTP {e.code}: {error_body[:200]}", file=sys.stderr)
+            return {"error": f"HTTP {e.code}", "detail": error_body[:200]}
+        except urllib.error.URLError as e:
+            print(f"  Network error: {e.reason}", file=sys.stderr)
+            return {"error": "network", "detail": str(e.reason)}
+        except Exception as e:
+            print(f"  Unexpected error: {e}", file=sys.stderr)
+            return {"error": "unknown", "detail": str(e)}
+
+    return {"error": "max_retries", "detail": "Exhausted retry attempts"}
+
+
+# ── LLM Gateway ──────────────────────────────────────────
+
+def llm_chat(messages, model="gpt-4.1-mini", temperature=0.3):
+    """Call AIsa's OpenAI-compatible chat completions endpoint."""
+    url = f"{AISA_LLM_BASE}/chat/completions"
+    data = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": 2000,
+    }
+    result = _request(url, method="POST", data=data)
+
+    if "error" in result:
+        return result
+
+    try:
+        return result["choices"][0]["message"]["content"]
+    except (KeyError, IndexError):
+        return {"error": "parse", "detail": "Unexpected LLM response format"}
+
+
+# ── Prediction Markets (Polymarket + Kalshi) ─────────────
+
+def search_prediction_markets(query, limit=5):
+    """Search Polymarket markets via fuzzy search.
+
+    GET /polymarket/markets — params: search, status, market_slug, limit.
+    Returns markets whose `side_a.id` / `side_b.id` token IDs feed
+    get_polymarket_price(). Yes price is a decimal probability (0.65 = 65%).
+    """
+    params = urllib.parse.urlencode({"search": query, "status": "open", "limit": limit})
+    url = f"{AISA_API_BASE}/polymarket/markets?{params}"
+    print(f"  📊 Prediction markets (Polymarket): {query}", file=sys.stderr)
+    return _request(url)
+
+
+def get_polymarket_price(token_id, at_time=None):
+    """Current (or historical) Polymarket price for a token.
+
+    GET /polymarket/market-price/{token_id} — params: token_id, at_time.
+    `token_id` comes from `side_a.id` / `side_b.id` in the markets response.
+    Returns a decimal probability (0-1).
+    """
+    url = f"{AISA_API_BASE}/polymarket/market-price/{urllib.parse.quote(str(token_id))}"
+    if at_time:
+        url += "?" + urllib.parse.urlencode({"at_time": at_time})
+    print(f"  📊 Polymarket price: {token_id}", file=sys.stderr)
+    return _request(url)
+
+
+def search_kalshi_markets(query, limit=5):
+    """Search Kalshi markets via fuzzy search.
+
+    GET /kalshi/markets — params: search, status, market_ticker.
+    Returns markets whose `market_ticker` feeds get_kalshi_price().
+    """
+    params = urllib.parse.urlencode({"search": query, "limit": limit})
+    url = f"{AISA_API_BASE}/kalshi/markets?{params}"
+    print(f"  📊 Prediction markets (Kalshi): {query}", file=sys.stderr)
+    return _request(url)
+
+
+def get_kalshi_price(market_ticker, at_time=None):
+    """Current (or historical) Kalshi yes/no price for a market.
+
+    GET /kalshi/market-price/{market_ticker} — params: market_ticker, at_time.
+    `market_ticker` comes from the markets response. Returns a decimal
+    probability (0-1).
+    """
+    url = f"{AISA_API_BASE}/kalshi/market-price/{urllib.parse.quote(str(market_ticker))}"
+    if at_time:
+        url += "?" + urllib.parse.urlencode({"at_time": at_time})
+    print(f"  📊 Kalshi price: {market_ticker}", file=sys.stderr)
+    return _request(url)
+
+
+# ── Twitter / X ──────────────────────────────────────────
+
+def search_twitter(query, query_type="Latest"):
+    """Search Twitter/X via AIsa relay.
+
+    GET /twitter/tweet/advanced_search — params: query, queryType
+    (Latest|Top), cursor.
+    """
+    params = urllib.parse.urlencode({"query": query, "queryType": query_type})
+    url = f"{AISA_API_BASE}/twitter/tweet/advanced_search?{params}"
+    print(f"  🐦 Twitter search: {query}", file=sys.stderr)
+    return _request(url)
+
+
+# ── News (Tavily) ────────────────────────────────────────
+
+def search_news(query, days=7, max_results=10):
+    """Search recent news via AIsa's Tavily relay."""
+    url = f"{AISA_API_BASE}/tavily/search"
+    data = {
+        "query": query,
+        "search_depth": "advanced",
+        "max_results": max_results,
+        "topic": "news",
+        "days": days,
+    }
+    print(f"  📰 News search: {query}", file=sys.stderr)
+    return _request(url, method="POST", data=data)
+
+
+# ── Stock / Market Data (MarketPulse) ────────────────────
+# All endpoints live under /financial/. Prices ~$0.001/call,
+# financials ~$0.002/call, macro ~$0.0005/call.
+
+def get_stock_prices(ticker, interval="day"):
+    """Historical stock prices.
+
+    GET /financial/prices — requires interval params
+    (e.g. ?ticker=AAPL&interval=day).
+    """
+    params = urllib.parse.urlencode({"ticker": ticker, "interval": interval})
+    url = f"{AISA_API_BASE}/financial/prices?{params}"
+    print(f"  💹 Stock prices: {ticker} ({interval})", file=sys.stderr)
+    return _request(url)
+
+
+def get_stock_news(ticker):
+    """Company news by ticker.
+
+    GET /financial/news — ?ticker=AAPL.
+    """
+    params = urllib.parse.urlencode({"ticker": ticker})
+    url = f"{AISA_API_BASE}/financial/news?{params}"
+    print(f"  📰 Stock news: {ticker}", file=sys.stderr)
+    return _request(url)
+
+
+def get_financial_metrics(ticker):
+    """Real-time financial metrics snapshot.
+
+    GET /financial/financial-metrics/snapshot — ?ticker=AAPL.
+    """
+    params = urllib.parse.urlencode({"ticker": ticker})
+    url = f"{AISA_API_BASE}/financial/financial-metrics/snapshot?{params}"
+    print(f"  📈 Financial metrics: {ticker}", file=sys.stderr)
+    return _request(url)
+
+
+def get_analyst_estimates(ticker):
+    """Analyst EPS estimates.
+
+    GET /financial/analyst-estimates — ?ticker=AAPL.
+    """
+    params = urllib.parse.urlencode({"ticker": ticker})
+    url = f"{AISA_API_BASE}/financial/analyst-estimates?{params}"
+    print(f"  🎯 Analyst estimates: {ticker}", file=sys.stderr)
+    return _request(url)
+
+
+def get_insider_trades(ticker):
+    """Insider trades.
+
+    GET /financial/insider-trades — ?ticker=AAPL.
+    """
+    params = urllib.parse.urlencode({"ticker": ticker})
+    url = f"{AISA_API_BASE}/financial/insider-trades?{params}"
+    print(f"  🕵️  Insider trades: {ticker}", file=sys.stderr)
+    return _request(url)
+
+
+def get_interest_rates():
+    """Current interest rates snapshot.
+
+    GET /financial/macro/interest-rates/snapshot.
+    """
+    url = f"{AISA_API_BASE}/financial/macro/interest-rates/snapshot"
+    print(f"  🏦 Interest rates snapshot", file=sys.stderr)
+    return _request(url)
+
+
+# ── Perplexity (supplemental) ────────────────────────────
+
+def perplexity_search(query):
+    """Supplemental deep research via AIsa's Perplexity relay."""
+    url = f"{AISA_API_BASE}/perplexity/search"
+    data = {"query": query}
+    print(f"  🔍 Perplexity: {query}", file=sys.stderr)
+    return _request(url, method="POST", data=data)

--- a/trend-forecast/scripts/trend_forecast.py
+++ b/trend-forecast/scripts/trend_forecast.py
@@ -223,7 +223,7 @@ def synthesize_forecast(topic, signals, sources_hit):
 
 # ── Step 7: Format output ───────────────────────────────────
 
-def format_markdown(forecast, topic):
+def format_markdown(forecast, topic, signals=None, sources_hit=None):
     """Format forecast as readable markdown."""
     direction_emoji = {
         "bullish": "🟢",
@@ -268,6 +268,22 @@ def format_markdown(forecast, topic):
         lines.append("")
         for gap in gaps:
             lines.append(f"- ⚠️ {gap}")
+        lines.append("")
+
+    if signals is not None:
+        def status(key):
+            return "✅" if signals.get(key) else "❌"
+
+        hit = sources_hit if sources_hit is not None else sum(
+            1 for k in ("prediction_markets", "twitter", "news", "stocks")
+            if signals.get(k)
+        )
+        lines.append(f"## Data Sources ({hit}/4)")
+        lines.append("")
+        lines.append(f"- 📊 Prediction Markets: {status('prediction_markets')}")
+        lines.append(f"- 🐦 Twitter/X Sentiment: {status('twitter')}")
+        lines.append(f"- 📰 News (Tavily): {status('news')}")
+        lines.append(f"- 💹 Market Data: {status('stocks')}")
         lines.append("")
 
     lines.append("---")
@@ -340,7 +356,7 @@ def main():
     if args.output == "json":
         output = json.dumps(forecast, indent=2)
     else:
-        output = format_markdown(forecast, args.query)
+        output = format_markdown(forecast, args.query, signals, sources_hit)
 
     print(output)
 

--- a/trend-forecast/scripts/trend_forecast.py
+++ b/trend-forecast/scripts/trend_forecast.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Trend Forecaster — Multi-signal trend analysis powered by AIsa.
+
+Usage:
+    python3 trend_forecast.py "Will the Fed cut rates in 2026?"
+    python3 trend_forecast.py "Tesla outlook" --output json
+    python3 trend_forecast.py "AI chip market" --output markdown --save report.md
+
+Chains 5 AIsa API endpoints:
+  1. LLM Gateway  (query decomposition + synthesis)
+  2. Prediction Markets  (contract odds)
+  3. Twitter/X  (social sentiment)
+  4. Tavily  (news velocity)
+  5. MarketPulse  (stock/financial data)
+"""
+
+import argparse
+import json
+import sys
+import os
+import textwrap
+from datetime import datetime
+
+# Add scripts dir to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import aisa_client as aisa
+
+
+# ── Step 1: Decompose query into source-specific searches ───
+
+DECOMPOSE_PROMPT = """You decompose a user's trend query into targeted search terms for 4 data sources.
+
+Rules:
+- prediction_market_query: Short phrase matching Polymarket/Kalshi contract titles (e.g. "Fed rate cut 2026", "Trump election")
+- twitter_query: Hashtags, keywords, or phrases people tweet about this topic
+- news_query: News-oriented search query for the last 7 days
+- stock_symbols: List of 0-5 relevant ticker symbols. Empty list if not a financial topic.
+  stock_symbols should only contain real stock ticker symbols (e.g. AAPL, NVDA, TLT).
+  Do NOT use abbreviations for institutions like FED, SEC, or FDA.
+  For Federal Reserve topics, use rate-sensitive ETFs like TLT, BND, or financials like JPM, GS.
+  Return an empty list if no real tickers are relevant.
+- topic_summary: One sentence describing what the user wants to forecast
+
+Respond ONLY with valid JSON, no markdown fences:
+{"prediction_market_query": "...", "twitter_query": "...", "news_query": "...", "stock_symbols": ["..."], "topic_summary": "..."}"""
+
+
+def decompose_query(user_query):
+    """Break user query into source-specific search terms via LLM."""
+    print("\n⚙️  Decomposing query...", file=sys.stderr)
+    result = aisa.llm_chat(
+        messages=[
+            {"role": "system", "content": DECOMPOSE_PROMPT},
+            {"role": "user", "content": user_query},
+        ],
+        model="gpt-4.1-mini",
+        temperature=0.2,
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        print(f"  ❌ LLM decomposition failed: {result}", file=sys.stderr)
+        return None
+
+    try:
+        # Strip markdown fences if present
+        cleaned = result.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.split("\n", 1)[1].rsplit("```", 1)[0]
+        return json.loads(cleaned)
+    except (json.JSONDecodeError, AttributeError) as e:
+        print(f"  ❌ Failed to parse decomposition: {e}", file=sys.stderr)
+        print(f"  Raw response: {result[:300]}", file=sys.stderr)
+        return None
+
+
+# ── Step 2-5: Gather signals from each source ──────────────
+
+def gather_signals(queries):
+    """Gather data from all 4 sources. Returns dict of results."""
+    signals = {
+        "prediction_markets": None,
+        "twitter": None,
+        "news": None,
+        "stocks": None,
+    }
+    sources_hit = 0
+
+    # Prediction Markets
+    print("\n📊 Querying prediction markets...", file=sys.stderr)
+    pm_result = aisa.search_prediction_markets(queries["prediction_market_query"])
+    if "error" not in pm_result:
+        signals["prediction_markets"] = pm_result
+        sources_hit += 1
+    else:
+        print(f"  ⚠️  Prediction markets unavailable: {pm_result.get('detail', 'unknown')}", file=sys.stderr)
+
+    # Twitter / X
+    print("\n🐦 Querying Twitter/X sentiment...", file=sys.stderr)
+    tw_result = aisa.search_twitter(queries["twitter_query"])
+    if "error" not in tw_result:
+        signals["twitter"] = tw_result
+        sources_hit += 1
+    else:
+        print(f"  ⚠️  Twitter unavailable: {tw_result.get('detail', 'unknown')}", file=sys.stderr)
+
+    # News via Tavily
+    print("\n📰 Querying news sources...", file=sys.stderr)
+    news_result = aisa.search_news(queries["news_query"])
+    if "error" not in news_result:
+        signals["news"] = news_result
+        sources_hit += 1
+    else:
+        print(f"  ⚠️  News unavailable: {news_result.get('detail', 'unknown')}", file=sys.stderr)
+
+    # Stock data (if applicable) — MarketPulse /financial/ endpoints
+    symbols = queries.get("stock_symbols", [])
+    if symbols and symbols != [""] and len(symbols) > 0:
+        print("\n💹 Querying market data...", file=sys.stderr)
+        stock_data = {}
+        for symbol in symbols[:5]:  # Cap at 5 symbols
+            if not symbol:
+                continue
+            ticker_signals = {}
+            prices = aisa.get_stock_prices(symbol, interval="day")
+            if "error" not in prices:
+                ticker_signals["prices"] = prices
+            metrics = aisa.get_financial_metrics(symbol)
+            if "error" not in metrics:
+                ticker_signals["metrics"] = metrics
+            news = aisa.get_stock_news(symbol)
+            if "error" not in news:
+                ticker_signals["news"] = news
+            if ticker_signals:
+                stock_data[symbol] = ticker_signals
+        if stock_data:
+            signals["stocks"] = stock_data
+            sources_hit += 1
+        else:
+            print("  ⚠️  No stock data returned", file=sys.stderr)
+    else:
+        print("\n💹 Skipping stock data (non-financial topic)", file=sys.stderr)
+
+    return signals, sources_hit
+
+
+# ── Step 6: Synthesize forecast via LLM ─────────────────────
+
+SYNTHESIS_PROMPT = """You are a trend analyst. Given structured signals from multiple data sources
+(prediction markets, Twitter/X, news, and optionally stock data), produce a trend forecast.
+
+Rules:
+- Weigh sources by reliability: prediction markets > stock data > news > twitter
+- Note when sources AGREE vs CONFLICT — agreement raises confidence
+- Never present odds as certainties. Say "markets price at X%" not "X will happen"
+- If fewer than 3 sources provided data, set confidence below 40 and note the limitation
+- Include a financial disclaimer if stock data is involved
+
+Respond ONLY with valid JSON, no markdown fences:
+{
+  "trend_direction": "bullish|bearish|neutral|mixed",
+  "confidence_score": 0-100,
+  "time_horizon": "short description of relevant timeframe",
+  "headline": "one-line summary of the forecast",
+  "analysis": "2-3 paragraph analysis synthesizing all signals",
+  "signal_agreement": "high|medium|low",
+  "key_signals": ["signal 1", "signal 2", "signal 3"],
+  "risks": ["risk 1", "risk 2"],
+  "data_gaps": ["any sources that returned no data"]
+}"""
+
+
+def synthesize_forecast(topic, signals, sources_hit):
+    """Pass all signals to LLM for synthesis into a forecast."""
+    print("\n🧠 Synthesizing forecast...", file=sys.stderr)
+
+    # Build the signal summary for the LLM
+    signal_text = f"TOPIC: {topic}\n\n"
+
+    if signals["prediction_markets"]:
+        signal_text += f"PREDICTION MARKETS:\n{json.dumps(signals['prediction_markets'], indent=2)[:2000]}\n\n"
+    else:
+        signal_text += "PREDICTION MARKETS: No data available\n\n"
+
+    if signals["twitter"]:
+        signal_text += f"TWITTER SENTIMENT:\n{json.dumps(signals['twitter'], indent=2)[:2000]}\n\n"
+    else:
+        signal_text += "TWITTER SENTIMENT: No data available\n\n"
+
+    if signals["news"]:
+        signal_text += f"NEWS VELOCITY:\n{json.dumps(signals['news'], indent=2)[:2000]}\n\n"
+    else:
+        signal_text += "NEWS VELOCITY: No data available\n\n"
+
+    if signals["stocks"]:
+        signal_text += f"STOCK/MARKET DATA:\n{json.dumps(signals['stocks'], indent=2)[:2000]}\n\n"
+    else:
+        signal_text += "STOCK/MARKET DATA: N/A\n\n"
+
+    signal_text += f"SOURCES WITH DATA: {sources_hit}/4\n"
+
+    result = aisa.llm_chat(
+        messages=[
+            {"role": "system", "content": SYNTHESIS_PROMPT},
+            {"role": "user", "content": signal_text},
+        ],
+        model="gpt-4.1-mini",
+        temperature=0.3,
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return None
+
+    try:
+        cleaned = result.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.split("\n", 1)[1].rsplit("```", 1)[0]
+        return json.loads(cleaned)
+    except (json.JSONDecodeError, AttributeError):
+        print(f"  ❌ Failed to parse synthesis", file=sys.stderr)
+        return None
+
+
+# ── Step 7: Format output ───────────────────────────────────
+
+def format_markdown(forecast, topic):
+    """Format forecast as readable markdown."""
+    direction_emoji = {
+        "bullish": "🟢",
+        "bearish": "🔴",
+        "neutral": "🟡",
+        "mixed": "🔵",
+    }
+
+    emoji = direction_emoji.get(forecast.get("trend_direction", ""), "⚪")
+    conf = forecast.get("confidence_score", "?")
+    direction = forecast.get("trend_direction", "unknown").upper()
+
+    lines = []
+    lines.append(f"# 📈 TREND FORECAST: {forecast.get('headline', topic)}")
+    lines.append("")
+    lines.append(f"**Direction:** {emoji} {direction}")
+    lines.append(f"**Confidence:** {conf}/100")
+    lines.append(f"**Signal Agreement:** {forecast.get('signal_agreement', 'unknown')}")
+    lines.append(f"**Time Horizon:** {forecast.get('time_horizon', 'not specified')}")
+    lines.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M UTC')}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Analysis")
+    lines.append("")
+    lines.append(forecast.get("analysis", "No analysis available."))
+    lines.append("")
+    lines.append("## Key Signals")
+    lines.append("")
+    for sig in forecast.get("key_signals", []):
+        lines.append(f"- {sig}")
+    lines.append("")
+    lines.append("## Risks & Caveats")
+    lines.append("")
+    for risk in forecast.get("risks", []):
+        lines.append(f"- {risk}")
+    lines.append("")
+
+    gaps = forecast.get("data_gaps", [])
+    if gaps:
+        lines.append("## Data Gaps")
+        lines.append("")
+        for gap in gaps:
+            lines.append(f"- ⚠️ {gap}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("*This is informational analysis, not financial advice. "
+                 "Prediction market odds reflect crowd sentiment, not certainties. "
+                 "Powered by AIsa (aisa.one).*")
+
+    return "\n".join(lines)
+
+
+# ── Main ────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Multi-signal trend forecasting powered by AIsa",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""
+            Examples:
+              python3 trend_forecast.py "Will the Fed cut rates?"
+              python3 trend_forecast.py "Tesla outlook" --output json
+              python3 trend_forecast.py "AI market" --save report.md
+        """),
+    )
+    parser.add_argument("query", help="The trend/forecast question to analyze")
+    parser.add_argument(
+        "--output", choices=["markdown", "json"], default="markdown",
+        help="Output format (default: markdown)"
+    )
+    parser.add_argument("--save", metavar="FILE", help="Save output to file")
+    parser.add_argument(
+        "--model", default="gpt-4.1-mini",
+        help="LLM model for synthesis (default: gpt-4.1-mini)"
+    )
+
+    args = parser.parse_args()
+
+    print(f"🔮 Trend Forecaster v1.0.0", file=sys.stderr)
+    print(f"   Query: {args.query}", file=sys.stderr)
+    print(f"   Powered by AIsa (aisa.one)", file=sys.stderr)
+
+    # Step 1: Decompose
+    queries = decompose_query(args.query)
+    if not queries:
+        print("❌ Failed to decompose query. Check your AISA_API_KEY.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n   Topic: {queries.get('topic_summary', args.query)}", file=sys.stderr)
+    print(f"   Stocks: {queries.get('stock_symbols', [])}", file=sys.stderr)
+
+    # Steps 2-5: Gather signals
+    signals, sources_hit = gather_signals(queries)
+    print(f"\n✅ Data gathered from {sources_hit}/4 sources", file=sys.stderr)
+
+    if sources_hit < 2:
+        print("⚠️  WARNING: Fewer than 2 sources returned data. "
+              "Forecast will have very low confidence.", file=sys.stderr)
+
+    # Step 6: Synthesize
+    forecast = synthesize_forecast(
+        queries.get("topic_summary", args.query),
+        signals,
+        sources_hit,
+    )
+
+    if not forecast:
+        print("❌ Failed to synthesize forecast.", file=sys.stderr)
+        sys.exit(1)
+
+    # Step 7: Output
+    if args.output == "json":
+        output = json.dumps(forecast, indent=2)
+    else:
+        output = format_markdown(forecast, args.query)
+
+    print(output)
+
+    if args.save:
+        with open(args.save, "w") as f:
+            f.write(output)
+        print(f"\n💾 Saved to {args.save}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add `trend-forecast` skill

Multi-signal trend forecasting that chains 5 AIsa API categories into a single analysis. One prompt → prediction markets + Twitter + news + financial data + LLM synthesis → confidence-scored forecast.

### What it does

Given any trend question ("Will the Fed cut rates in 2026?", "What's the outlook on NVDA before earnings?"), the skill:

1. **Decomposes** the query into source-specific search terms via LLM
2. **Queries Polymarket & Kalshi** for prediction market odds
3. **Searches Twitter/X** for social sentiment and discussion volume
4. **Scans news** via Tavily for article velocity and headline sentiment
5. **Pulls financial data** via MarketPulse (prices, metrics, analyst estimates)
6. **Synthesizes** all signals into a forecast with confidence score (0-100), trend direction, key signals, and risks

### AIsa endpoints used

| Source | Endpoints | Cost |
|---|---|---|
| Prediction Markets | `/polymarket/markets`, `/kalshi/markets` | $0.010/call |
| Twitter/X | `/twitter/tweet/advanced_search` | per call |
| News (Tavily) | `/tavily/search` | per call |
| MarketPulse | `/financial/prices`, `/financial/financial-metrics/snapshot`, `/financial/news` | ~$0.001-0.002/call |
| LLM Gateway | `/v1/chat/completions` (gpt-4.1-mini) | per token |

Total cost per forecast: ~$0.05-0.10

### Example output

```
📈 TREND FORECAST: Markets and news indicate moderate probability of Fed rate cuts in 2026

Direction: 🔴 BEARISH
Confidence: 75/100
Signal Agreement: medium
Time Horizon: throughout 2026 and into early 2027

Key Signals:
- Prediction markets price ~52-54% chance of Fed rate cuts in 2026
- News reports highlight mixed views with some expecting front-loaded hikes before cuts
- Bond market data shows cautious financial metrics without strong easing signals

Data Sources (4/4):
- 📊 Prediction Markets: ✅
- 🐦 Twitter/X Sentiment: ✅
- 📰 News (Tavily): ✅
- 💹 Market Data: ✅
```

### Why this skill is different

AIsa has 8 search skills and 9 financial skills, but none that **chain across categories**. This is the first skill that combines prediction markets + social + news + financial data into one workflow. It showcases AIsa's unified gateway value — one API key replaces what would normally require Polymarket API + Twitter API + Tavily API + a financial data provider + an LLM provider.

### Files

```
trend-forecast/
├── SKILL.md              # OpenClaw-compatible skill definition
├── README.md             # Install, usage, and examples
├── .gitignore
├── scripts/
│   ├── aisa_client.py    # Reusable AIsa API client
│   └── trend_forecast.py # Main orchestrator
└── references/
    └── api_endpoints.md  # Full endpoint documentation
```

### Testing

Tested locally via CLI and on AIsaClaw. All 4 data sources returning live data successfully.
<img width="1587" height="499" alt="image" src="https://github.com/user-attachments/assets/7c3cdcb7-15a2-4d37-9a89-c8c42bb447f7" />
