### PR TITLE
fix: make skill frontmatter validator-compliant

### DIFF
--- a/creative/media-gen/SKILL.md
+++ b/creative/media-gen/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: media-gen
-description: "Generate images and videos with AIsa. Four image models (Google Gemini 3 Pro Image, Alibaba Wan 2.7 image + image-pro, ByteDance Seedream) and four Wan video variants (wan2.6/2.7 × t2v/i2v). One API key; the client routes each model to the correct endpoint automatically."
+description: Generate images and videos with AIsa. Four image models (Google Gemini 3 Pro Image, Alibaba Wan 2.7 image + image-pro, ByteDance Seedream) and four Wan video variants (wan2.6/2.7 × t2v/i2v). One API key; the client routes each model to the correct endpoint automatically.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "🎬", "homepage": "https://aisa.one", "requires": {"bins": ["python3", "curl"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🎬
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      - curl
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Media Gen 🎬
 

--- a/financial/crypto-market-data/SKILL.md
+++ b/financial/crypto-market-data/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: crypto-market-data
-description: "Query real-time and historical cryptocurrency market data via CoinGecko — simple prices, coin details, historical charts, OHLC candles, token prices by contract address, market-cap rankings, exchange data and tickers, categories, trending searches, and crypto news. Use for crypto research, price tracking, on-chain token lookup, portfolio analysis, and market-cap screening."
+description: Query real-time and historical cryptocurrency market data via CoinGecko — simple prices, coin details, historical charts, OHLC candles, token prices by contract address, market-cap rankings, exchange data and tickers, categories, trending searches, and crypto news. Use for crypto research, price tracking, on-chain token lookup, portfolio analysis, and market-cap screening.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "🪙", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🪙
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Crypto Market Data 🪙
 

--- a/financial/market/SKILL.md
+++ b/financial/market/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: market
 description: 'Query real-time and historical financial data across equities and crypto—prices, market moves, metrics, and trends for analysis, alerts, and reporting. Use when: the user needs market data, stock analysis, watchlists, or portfolio workflows.'
-version: 1.0.1
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
   aisa:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.1
 ---
 
 # AIsa Market (`market`) 📊

--- a/financial/marketpulse/SKILL.md
+++ b/financial/marketpulse/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: marketpulse
-description: "Query real-time and historical financial data for equities—prices, news, financial statements, metrics, analyst estimates, insider and institutional activity, SEC filings, earnings press releases, segmented revenues, stock screening, and macro interest rates."
+description: Query real-time and historical financial data for equities—prices, news, financial statements, metrics, analyst estimates, insider and institutional activity, SEC filings, earnings press releases, segmented revenues, stock screening, and macro interest rates.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "📊", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 📊
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # MarketPulse 📊
 

--- a/financial/prediction-market-arbitrage/SKILL.md
+++ b/financial/prediction-market-arbitrage/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: prediction-market-arbitrage
-description: "Find and analyze arbitrage opportunities across prediction markets like Polymarket and Kalshi."
+description: Find and analyze arbitrage opportunities across prediction markets like Polymarket and Kalshi.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "⚖️", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: ⚖️
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Cross-Platform Prediction Market Arbitrage ⚖️
 

--- a/financial/prediction-market-data/SKILL.md
+++ b/financial/prediction-market-data/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: prediction-market-data
-description: "Prediction markets data - Polymarket, Kalshi markets, prices, positions, and trades"
+description: Prediction markets data - Polymarket, Kalshi markets, prices, positions, and trades
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "📈", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 📈
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Cross-Platform Prediction Market Data 📈
 

--- a/financial/stock-dividend/SKILL.md
+++ b/financial/stock-dividend/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: stock-dividend
 description: 'Analyze read-only dividend metrics for stocks via AIsa API. Provides yield, payout ratio, growth CAGR, safety score, income rating, and Dividend Aristocrat/King status without placing trades, making purchases, or managing brokerage accounts. Use when: the user needs market data, stock analysis, dividend research, or read-only financial data workflows.'
-version: 1.0.2
-clawhub-slug: stock-dividend-aisa
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
   aisa:
@@ -14,6 +12,9 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.2
+  openclaw:
+    clawhub-slug: stock-dividend-aisa
 ---
 
 # Dividend Analysis — AIsa Edition

--- a/financial/trend-forecast/SKILL.md
+++ b/financial/trend-forecast/SKILL.md
@@ -1,34 +1,32 @@
 ---
 name: trend-forecast
-description: >
-  Multi-signal trend forecasting for autonomous agents. Combines prediction market
-  odds, Twitter/X social sentiment, news velocity, and stock market data into a
-  unified trend analysis with confidence scoring. Powered by AIsa — one API key,
-  five data streams.
-version: 1.0.0
-triggers:
-  - "forecast trend"
-  - "predict what happens with"
-  - "trend analysis for"
-  - "what's the outlook on"
-  - "will X happen"
-  - "what are the odds of"
-  - "sentiment analysis on"
-  - "market outlook for"
-tools:
-  - bash
-  - read
-  - write
+description: 'Multi-signal trend forecasting for autonomous agents. Combines prediction market odds, Twitter/X social sentiment, news velocity, and stock market data into a unified trend analysis with confidence scoring. Powered by AIsa — one API key, five data streams.
+
+  '
 metadata:
   openclaw:
-    emoji: "📈"
+    emoji: 📈
     requires:
       bins:
-        - curl
-        - python3
+      - curl
+      - python3
       env:
-        - AISA_API_KEY
+      - AISA_API_KEY
     primaryEnv: AISA_API_KEY
+    version: 1.0.0
+    triggers:
+    - forecast trend
+    - predict what happens with
+    - trend analysis for
+    - what's the outlook on
+    - will X happen
+    - what are the odds of
+    - sentiment analysis on
+    - market outlook for
+    tools:
+    - bash
+    - read
+    - write
 ---
 
 # Trend Forecast

--- a/financial/us-stock-analyst/SKILL.md
+++ b/financial/us-stock-analyst/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: us-stock-analyst
 description: 'Professional US stock analysis with financial data, news, social sentiment, and multi-model AI. Comprehensive reports at $0.02-0.10 per analysis. Use when: the user needs market data, stock analysis, watchlists, or portfolio workflows.'
-version: 1.0.1
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
   aisa:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.1
 ---
 
 # US Stock Analyst 📈

--- a/search-research/last30days-zh/SKILL.md
+++ b/search-research/last30days-zh/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: last30days-zh
 description: '聚合最近 30 天的 Reddit、X/Twitter、YouTube、TikTok、Instagram、Hacker News、Polymarket 和 web search 结果. Use when: the user needs recent multi-source research across the last 30 days.'
-version: 1.0.9
 license: MIT
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, bash, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
@@ -15,6 +14,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, bash, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.9
 ---
 
 # last30days 中文版

--- a/search-research/last30days/SKILL.md
+++ b/search-research/last30days/SKILL.md
@@ -1,10 +1,29 @@
 ---
 name: last30days
-description: "Research the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web search. Returns a ranked, clustered brief with citations. Use when the task needs recent social evidence, competitor comparisons, launch reactions, trend scans, or person/company profiles."
-homepage: https://aisa.one
+description: Research the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and grounded web search. Returns a ranked, clustered brief with citations. Use when the task needs recent social evidence, competitor comparisons, launch reactions, trend scans, or person/company profiles.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "📰", "homepage": "https://aisa.one", "requires": {"bins": ["python3", "bash"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 📰
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      - bash
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # last30days 📰
 

--- a/search-research/multi-source-search/SKILL.md
+++ b/search-research/multi-source-search/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: multi-source-search
-description: "Multi-source intelligent search for agents. Retrieval across web, scholar, Tavily, and Perplexity Sonar models."
+description: Multi-source intelligent search for agents. Retrieval across web, scholar, Tavily, and Perplexity Sonar models.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "🔎", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🔎
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Multi-source Search
 

--- a/search-research/perplexity-search/SKILL.md
+++ b/search-research/perplexity-search/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: perplexity-search
-description: "Perplexity Sonar search and answer generation through AIsa. Use when the task is specifically to call Perplexity Sonar, Sonar Pro, Sonar Reasoning Pro, or Sonar Deep Research for citation-backed web answers, analytical reasoning, or long-form research reports."
+description: Perplexity Sonar search and answer generation through AIsa. Use when the task is specifically to call Perplexity Sonar, Sonar Pro, Sonar Reasoning Pro, or Sonar Deep Research for citation-backed web answers, analytical reasoning, or long-form research reports.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "🔎", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🔎
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Perplexity-Search
 

--- a/social-media/aisa-twitter-api/SKILL.md
+++ b/social-media/aisa-twitter-api/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aisa-twitter-api
 description: 'Twitter/X research, monitoring, watchlists, and OAuth-approved posting through AIsa. Use when: the user needs one flagship Twitter skill for trend tracking, competitor monitoring, timeline analysis, or approved posting without sharing passwords. Supports search, watchlists, relay-based reads, and OAuth-gated text or media posting.'
-version: 1.0.5
 license: Apache-2.0
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.5
 ---
 
 # AIsa Twitter API Command Center

--- a/social-media/aisa-twitter-command-center/SKILL.md
+++ b/social-media/aisa-twitter-command-center/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aisa-twitter-command-center
 description: Search X/Twitter profiles, tweets, trends, lists, communities, and Spaces through the AIsa relay, then support approved posting workflows with OAuth. Use when the user asks for Twitter research, monitoring, or posting without sharing passwords.
-version: 1.0.3
 license: Apache-2.0
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.3
 ---
 
 # AIsa Twitter Command Center

--- a/social-media/aisa-twitter-post-engage/SKILL.md
+++ b/social-media/aisa-twitter-post-engage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aisa-twitter-post-engage
 description: Search X/Twitter profiles, tweets, trends, and approved engagement actions through the AIsa relay. Use when the user asks for Twitter/X research, posting, likes, follows, or related workflows without sharing passwords.
-version: 1.0.3
 license: Apache-2.0
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries python3, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.3
 ---
 
 # AIsa Twitter Post Engage

--- a/social-media/aisa-youtube-search/SKILL.md
+++ b/social-media/aisa-youtube-search/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aisa-youtube-search
 description: Search YouTube videos, channels, and playlists through the AIsa YouTube relay with one API key. Use when the user asks for YouTube discovery, query expansion, or pagination without managing Google credentials.
-version: 1.0.1
 license: MIT-0
 compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, environment variables AISA_API_KEY and internet access to api.aisa.one.
 metadata:
@@ -14,6 +13,7 @@ metadata:
       - AISA_API_KEY
     primaryEnv: AISA_API_KEY
     compatibility: Designed for Agent Skills compatible clients such as OpenClaw, Claude Code, Hermes, and GitHub-backed skill catalogs. Requires system binaries curl, environment variables AISA_API_KEY and internet access to api.aisa.one.
+    version: 1.0.1
 ---
 
 # AIsa YouTube Search

--- a/social-media/twitter-autopilot/SKILL.md
+++ b/social-media/twitter-autopilot/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: twitter-autopilot
-description: "Searches and reads X (Twitter): profiles, timelines, mentions, followers, tweet search, trends, lists, communities, and Spaces. Publishes posts, likes/unlikes tweets, and follows/unfollows users after the user completes OAuth in the browser. Use when the user asks about Twitter/X data, social listening, posting, or interacting with tweets/users without sharing account passwords."
+description: 'Searches and reads X (Twitter): profiles, timelines, mentions, followers, tweet search, trends, lists, communities, and Spaces. Publishes posts, likes/unlikes tweets, and follows/unfollows users after the user completes OAuth in the browser. Use when the user asks about Twitter/X data, social listening, posting, or interacting with tweets/users without sharing account passwords.'
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "🐦", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🐦
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # Twitter Autopilot 🐦
 

--- a/social-media/youtube-serp/SKILL.md
+++ b/social-media/youtube-serp/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: youtube-serp
-description: "YouTube SERP for agents. Search top-ranking videos, channels, and trends for content research and competitor tracking."
+description: YouTube SERP for agents. Search top-ranking videos, channels, and trends for content research and competitor tracking.
 license: MIT
-compatibility: "Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY."
-metadata: {"aisa": {"emoji": "📺", "homepage": "https://aisa.one", "requires": {"bins": ["curl", "python3"], "env": ["AISA_API_KEY"]}, "primaryEnv": "AISA_API_KEY", "harnesses": ["claude-code", "claude", "opencode", "cursor", "codex", "gemini-cli", "openclaw", "hermes", "goose"]}}
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3, a POSIX shell, and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 📺
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - curl
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
 ---
 # YouTube SERP 📺
 


### PR DESCRIPTION
## 修改

修复 19 个现有 Skill 的 frontmatter，使其通过固定版本 `skills-ref==0.1.1`：

- 将不被官方 schema 接受的顶层 `version`、`triggers`、`tools`、`clawhub-slug` 移入各自 vendor metadata；
- 将原有 `metadata.aisa` / `metadata.openclaw` 内容迁移为 validator 接受的 metadata 结构；
- 保留原字段值和 vendor 语义；
- 不修改正文、脚本、README 或运行行为。

## 范围

PR 已在合并后的 PR #45 / 最新 `main` 上重建：

- 1 个提交；
- 只修改 19 个 `SKILL.md`；
- 不再包含旧质量门禁、workflow、文档或 baseline 文件；
- 19 个文件的 frontmatter 后正文与 `main` 字节级一致。

## 验证

- 19 个受影响 Skill：validator PASS；
- 源仓库全部 42 个 Skill：42/42 validator PASS；
- 六个分类真实导出包：42/42 validator PASS；
- 新 changed-scope catalog gate：PASS；
- 门禁单测：15/15 PASS；
- Pyright：0 errors；
- actionlint：PASS；
- `--all` 只剩 3 条与本 PR 无关的历史问题：
  - 2 个 README → LICENSE 本地断链；
  - 1 个 Shell 语法错误。

本 PR 不修改 Skill 正文或行为，不自动合并或部署。