### PR TITLE
fix: resolve AISA_API_KEY and model pins from credential files, not just the environment

### DIFF
--- a/.github/scripts/tests/test_credentials_resolution.py
+++ b/.github/scripts/tests/test_credentials_resolution.py
@@ -1,0 +1,389 @@
+"""Contract tests for the AISA credential/config resolver shared by AIsa skills.
+
+Several skills carry a byte-identical `_resolve_aisa_api_key()` (last30days
+generalises it to `_resolve_from_files(name)`), because a skill has to be
+self-contained and cannot import across skill directories. That duplication is
+the reason these tests live here rather than in any one skill: this file is the
+single place asserting that every copy still behaves the same.
+
+Resolution order under test:
+
+    1. the environment variable
+    2. ~/.aisa/credentials
+    3. $HERMES_HOME/profiles/$HERMES_PROFILE/.env   (when HERMES_PROFILE is set)
+    4. $HERMES_HOME/.env
+
+A sibling profile is never read: on a host running several profiles that would
+both leak credentials across profiles and hand back the wrong tenant's key.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from typing import Callable
+
+REPO = Path(__file__).resolve().parents[3]
+
+# (label, path, exported symbol) — every copy that must satisfy the contract.
+TARGETS: list[tuple[str, str, str]] = [
+    ("marketpulse", "financial/marketpulse/scripts/market_client.py", "_resolve_aisa_api_key"),
+    ("prediction-market-data", "financial/prediction-market-data/scripts/prediction_market_client.py", "_resolve_aisa_api_key"),
+    ("multi-source-search", "search-research/multi-source-search/scripts/search_client.py", "_resolve_aisa_api_key"),
+    ("aisa-twitter-api", "social-media/aisa-twitter-api/scripts/twitter_client.py", "_resolve_aisa_api_key"),
+    ("aisa-twitter-api-oauth", "social-media/aisa-twitter-api/scripts/twitter_oauth_client.py", "_resolve_aisa_api_key"),
+    ("last30days", "search-research/last30days/scripts/lib/env.py", "_resolve_aisa_api_key"),
+]
+
+# Neutralised for every case so a real value on the machine running the tests
+# can never make one pass.
+SCRUB = ("AISA_API_KEY", "AISA_MODEL", "HERMES_HOME", "HERMES_PROFILE", "HOME",
+         "USERPROFILE", "LAST30DAYS_CONFIG_DIR", "XDG_CONFIG_HOME")
+
+
+def load(path: Path) -> ModuleType:
+    """Import a target file, honouring package layout when there is one."""
+    pkg_parts: list[str] = []
+    anchor = path.parent
+    while (anchor / "__init__.py").exists():
+        pkg_parts.insert(0, anchor.name)
+        anchor = anchor.parent
+
+    added = str(anchor) not in sys.path
+    if added:
+        sys.path.insert(0, str(anchor))
+    try:
+        if pkg_parts:
+            dotted = ".".join(pkg_parts + [path.stem])
+            for stale in [m for m in sys.modules if m.split(".")[0] == pkg_parts[0]]:
+                del sys.modules[stale]
+            return importlib.import_module(dotted)
+        name = f"_t_{path.stem}_{abs(hash(str(path))) % 100000}"
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if added:
+            sys.path.remove(str(anchor))
+
+
+class Sandbox:
+    """Fake HOME + HERMES_HOME with a fully scrubbed environment."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name) / "home"
+        self.hermes = self.home / ".hermes"
+        (self.home / ".aisa").mkdir(parents=True)
+        (self.hermes / "profiles").mkdir(parents=True)
+        self._saved: dict[str, str | None] = {}
+
+    def __enter__(self) -> "Sandbox":
+        for key in SCRUB:
+            self._saved[key] = os.environ.pop(key, None)
+        os.environ["HOME"] = str(self.home)
+        os.environ["USERPROFILE"] = str(self.home)
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        self._tmp.cleanup()
+        return False
+
+    def credentials(self, text: str) -> None:
+        (self.home / ".aisa" / "credentials").write_text(text, encoding="utf-8")
+
+    def credentials_bytes(self, data: bytes) -> None:
+        (self.home / ".aisa" / "credentials").write_bytes(data)
+
+    def profile_env(self, name: str, text: str) -> None:
+        directory = self.hermes / "profiles" / name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".env").write_text(text, encoding="utf-8")
+        os.environ["HERMES_HOME"] = str(self.hermes)
+
+    def hermes_env(self, text: str) -> None:
+        (self.hermes / ".env").write_text(text, encoding="utf-8")
+        os.environ["HERMES_HOME"] = str(self.hermes)
+
+
+Setup = Callable[[Sandbox], None]
+
+
+def _env_wins(sb: Sandbox) -> None:
+    os.environ["AISA_API_KEY"] = "from-env"
+    sb.credentials("AISA_API_KEY=from-credentials\n")
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+
+
+def _credentials(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY=from-credentials\n")
+
+
+def _credentials_beat_profile(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY=from-credentials\n")
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+def _named_profile(sb: Sandbox) -> None:
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+def _sibling_never_read(sb: Sandbox) -> None:
+    sb.profile_env("aaa-other", "AISA_API_KEY=wrong-tenant\n")
+    sb.profile_env("zzz-mine", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "zzz-mine"
+
+
+def _no_profile_no_scan(sb: Sandbox) -> None:
+    # HERMES_PROFILE unset -> do NOT sweep profiles/*/.env.
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+
+
+def _hermes_env(sb: Sandbox) -> None:
+    # Under `hermes --profile X` this is the shape that fires: HERMES_HOME is
+    # the profile directory itself and HERMES_PROFILE is not set.
+    sb.hermes_env("AISA_API_KEY=from-hermes-env\n")
+
+
+def _nothing(sb: Sandbox) -> None:
+    pass
+
+
+def _empty_env_falls_through(sb: Sandbox) -> None:
+    os.environ["AISA_API_KEY"] = ""
+    sb.credentials("AISA_API_KEY=from-credentials\n")
+
+
+def _empty_value_falls_through(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY=\n")
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+def _double_quoted(sb: Sandbox) -> None:
+    sb.credentials('AISA_API_KEY="from-credentials"\n')
+
+
+def _single_quoted(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY='from-credentials'\n")
+
+
+def _export_prefix(sb: Sandbox) -> None:
+    sb.credentials("export AISA_API_KEY=from-credentials\n")
+
+
+def _whole_line_comment_ignored(sb: Sandbox) -> None:
+    sb.credentials("# AISA_API_KEY=commented-out\nAISA_API_KEY=from-credentials\n")
+
+
+def _inline_comment_stripped(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY=from-credentials  # my key\n")
+
+
+def _quoted_then_comment(sb: Sandbox) -> None:
+    # Regression: a whole-value quote check fails here (last char is a comment
+    # character, not a quote), so a naive parser takes the unquoted branch and
+    # returns the value with its quotes still attached — a garbage bearer token.
+    sb.credentials('AISA_API_KEY="from-credentials" # my key\n')
+
+
+def _single_quoted_then_comment(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY='from-credentials' # my key\n")
+
+
+def _quoted_then_tab_comment(sb: Sandbox) -> None:
+    sb.credentials('AISA_API_KEY="from-credentials"\t# my key\n')
+
+
+def _hash_inside_quotes_kept(sb: Sandbox) -> None:
+    sb.credentials('AISA_API_KEY="pa#ss"\n')
+
+
+def _hash_inside_quotes_plus_comment(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY='pa#ss' # my key\n")
+
+
+def _unterminated_quote(sb: Sandbox) -> None:
+    sb.credentials('AISA_API_KEY="from-credentials\n')
+
+
+def _spaces_inside_quotes_kept(sb: Sandbox) -> None:
+    sb.credentials('AISA_API_KEY="from credentials"\n')
+
+
+def _spaces_around_equals(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY = from-credentials\n")
+
+
+def _similar_names_ignored(sb: Sandbox) -> None:
+    sb.credentials("OTHER=nope\nAISA_API_KEY_SUFFIX=nope2\nAISA_API_KEY=from-credentials\n")
+
+
+def _trailing_whitespace_stripped(sb: Sandbox) -> None:
+    sb.credentials("AISA_API_KEY=from-credentials   \n")
+
+
+def _crlf(sb: Sandbox) -> None:
+    sb.credentials_bytes(b"AISA_API_KEY=from-credentials\r\n")
+
+
+def _utf8_bom(sb: Sandbox) -> None:
+    sb.credentials_bytes(b"\xef\xbb\xbfAISA_API_KEY=from-credentials\n")
+
+
+def _non_utf8_does_not_raise(sb: Sandbox) -> None:
+    # UnicodeDecodeError is a ValueError, not an OSError: a bare `except OSError`
+    # lets it escape and the resolver raises despite documenting that it never
+    # does. The corrupt value must also not be returned.
+    sb.credentials_bytes(b"AISA_API_KEY=\xff\xfe\x80bad\n")
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+def _utf16_does_not_raise(sb: Sandbox) -> None:
+    sb.credentials_bytes("AISA_API_KEY=utf16\n".encode("utf-16"))
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+def _unreadable_file_skipped(sb: Sandbox) -> None:
+    # A directory where a file is expected must fall through, not raise.
+    (sb.home / ".aisa" / "credentials").mkdir()
+    sb.profile_env("aisa-cio", "AISA_API_KEY=from-profile\n")
+    os.environ["HERMES_PROFILE"] = "aisa-cio"
+
+
+CASES: list[tuple[str, Setup, str]] = [
+    ("env var wins over every file", _env_wins, "from-env"),
+    ("~/.aisa/credentials", _credentials, "from-credentials"),
+    ("credentials beat the profile .env", _credentials_beat_profile, "from-credentials"),
+    ("named profile .env", _named_profile, "from-profile"),
+    ("sibling profile is never read", _sibling_never_read, "from-profile"),
+    ("no HERMES_PROFILE means no sweep", _no_profile_no_scan, ""),
+    ("$HERMES_HOME/.env as last resort", _hermes_env, "from-hermes-env"),
+    ("nothing found returns empty", _nothing, ""),
+    ("empty env var falls through", _empty_env_falls_through, "from-credentials"),
+    ("empty value falls through", _empty_value_falls_through, "from-profile"),
+    ("double-quoted value", _double_quoted, "from-credentials"),
+    ("single-quoted value", _single_quoted, "from-credentials"),
+    ("export prefix", _export_prefix, "from-credentials"),
+    ("whole-line comment ignored", _whole_line_comment_ignored, "from-credentials"),
+    ("inline comment stripped", _inline_comment_stripped, "from-credentials"),
+    ('"value" then comment', _quoted_then_comment, "from-credentials"),
+    ("'value' then comment", _single_quoted_then_comment, "from-credentials"),
+    ('"value" then tab comment', _quoted_then_tab_comment, "from-credentials"),
+    ("# inside quotes is data", _hash_inside_quotes_kept, "pa#ss"),
+    ("# inside quotes, comment after", _hash_inside_quotes_plus_comment, "pa#ss"),
+    ("unterminated quote", _unterminated_quote, "from-credentials"),
+    ("spaces inside quotes kept", _spaces_inside_quotes_kept, "from credentials"),
+    ("spaces around =", _spaces_around_equals, "from-credentials"),
+    ("similar key names ignored", _similar_names_ignored, "from-credentials"),
+    ("trailing whitespace stripped", _trailing_whitespace_stripped, "from-credentials"),
+    ("CRLF line endings", _crlf, "from-credentials"),
+    ("UTF-8 BOM tolerated", _utf8_bom, "from-credentials"),
+    ("non-UTF-8 file does not raise", _non_utf8_does_not_raise, "from-profile"),
+    ("UTF-16 file does not raise", _utf16_does_not_raise, "from-profile"),
+    ("unreadable path skipped", _unreadable_file_skipped, "from-profile"),
+]
+
+
+class CredentialResolutionContract(unittest.TestCase):
+    def test_every_copy_satisfies_the_contract(self) -> None:
+        for label, rel, symbol in TARGETS:
+            path = REPO / rel
+            self.assertTrue(path.exists(), f"{label}: missing {rel}")
+            module = load(path)
+            resolve = getattr(module, symbol, None)
+            self.assertIsNotNone(resolve, f"{label}: {rel} does not export {symbol}()")
+            assert resolve is not None
+            for name, setup, expected in CASES:
+                with self.subTest(skill=label, case=name):
+                    with Sandbox() as sb:
+                        setup(sb)
+                        self.assertEqual(resolve(), expected)
+
+    def test_last30days_http_layer_uses_the_resolver(self) -> None:
+        """The HTTP layer must actually reach the header, not merely import it."""
+        http_path = REPO / "search-research/last30days/scripts/lib/http.py"
+        for name, setup, expected in [
+            ("credentials file", _credentials, "from-credentials"),
+            ("profile .env", _named_profile, "from-profile"),
+        ]:
+            with self.subTest(case=name):
+                with Sandbox() as sb:
+                    setup(sb)
+                    module = load(http_path)
+                    headers: dict[str, str] = {}
+                    module._inject_aisa_headers("https://api.aisa.one/apis/v1/x", headers, False)
+                    self.assertEqual(headers.get("Authorization"), f"Bearer {expected}")
+
+    def test_last30days_clean_mode_reads_nothing_from_disk(self) -> None:
+        """LAST30DAYS_CONFIG_DIR="" means hermetic.
+
+        evaluate_search_quality's create_eval_env() builds a deliberately minimal
+        environment to compare two revisions; picking the operator's model pin up
+        off disk there would silently change what is being measured.
+        """
+        env_path = REPO / "search-research/last30days/scripts/lib/env.py"
+        with Sandbox() as sb:
+            sb.credentials("AISA_API_KEY=from-credentials\nAISA_MODEL=from-credentials\n")
+            os.environ["LAST30DAYS_CONFIG_DIR"] = ""
+            module = load(env_path)
+            config = module.get_config()
+            self.assertIsNone(config["AISA_API_KEY"])
+            self.assertIsNone(config["AISA_MODEL"])
+
+        with Sandbox() as sb:
+            sb.credentials("AISA_API_KEY=from-credentials\nAISA_MODEL=from-credentials\n")
+            module = load(env_path)
+            config = module.get_config()
+            self.assertEqual(config["AISA_API_KEY"], "from-credentials")
+            self.assertEqual(config["AISA_MODEL"], "from-credentials")
+
+    def test_resolver_bodies_are_identical_across_skills(self) -> None:
+        """Byte-identical copies, so a fix in one cannot silently miss the rest."""
+        import ast
+
+        bodies: dict[str, str] = {}
+        for label, rel, _ in TARGETS:
+            source = (REPO / rel).read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            for node in tree.body:
+                if isinstance(node, ast.FunctionDef) and node.name in (
+                    "_resolve_aisa_api_key", "_resolve_from_files"
+                ):
+                    if node.name == "_resolve_aisa_api_key" and len(node.body) <= 2:
+                        continue  # last30days' thin back-compat alias
+                    lines = source.replace("\r\n", "\n").split("\n")
+                    assert node.end_lineno is not None
+                    # Compare the executable body only: last30days generalises the
+                    # signature and docstring, but the parsing must not drift.
+                    body_start = node.body[1].lineno - 1 if len(node.body) > 1 else node.lineno
+                    bodies[label] = "\n".join(lines[body_start:node.end_lineno])
+                    break
+
+        clients = {k: v for k, v in bodies.items() if k != "last30days"}
+        self.assertEqual(len(clients), 5, f"expected 5 client copies, got {sorted(clients)}")
+        self.assertEqual(len(set(clients.values())), 1,
+                         "client copies of the resolver have drifted apart")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/validate-skill-catalog.yaml
+++ b/.github/workflows/validate-skill-catalog.yaml
@@ -49,11 +49,18 @@ jobs:
       - name: Run quality-gate unit tests
         run: .venv/bin/python .github/scripts/tests/test_catalog_quality.py -v
 
+      # The AISA credential resolver is duplicated byte-for-byte across several
+      # skills (a skill must be self-contained and cannot import across skill
+      # dirs). This asserts every copy still behaves identically.
+      - name: Run credential-resolution contract tests
+        run: .venv/bin/python .github/scripts/tests/test_credentials_resolution.py -v
+
       - name: Type-check quality-gate code
         run: >-
           .venv/bin/pyright
           .github/scripts/catalog_quality.py
           .github/scripts/tests/test_catalog_quality.py
+          .github/scripts/tests/test_credentials_resolution.py
 
       - name: Validate catalog changes
         env:

--- a/financial/marketpulse/scripts/market_client.py
+++ b/financial/marketpulse/scripts/market_client.py
@@ -30,6 +30,67 @@ import urllib.error
 from typing import Any, Dict, List, Optional
 
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 class MarketClient:
     """AIsa Market - Unified Market Data API Client."""
 
@@ -37,7 +98,7 @@ class MarketClient:
 
     def __init__(self, api_key: Optional[str] = None):
         """Initialize the client with an API key."""
-        self.api_key = api_key or os.environ.get("AISA_API_KEY")
+        self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
                 "AISA_API_KEY is required. Set it via environment variable or pass to constructor."

--- a/financial/marketpulse/scripts/market_client.py
+++ b/financial/marketpulse/scripts/market_client.py
@@ -33,17 +33,29 @@ from typing import Any, Dict, List, Optional
 def _resolve_aisa_api_key() -> str:
     """Resolve AISA_API_KEY from the environment, then from known credential files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY". `~/.aisa/credentials` is the
+    cross-harness convention AgentSpec already documents for exactly this case
+    (plugin-core/inject.ts: "scripts resolve these as: env var ->
+    ~/.aisa/credentials").
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env; the middle one covers harnesses that identify the profile by name
+    instead. Only the running profile is ever read, never a sibling's, so a host
+    with several profiles cannot hand back the wrong tenant's key.
+
     Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
+
+    Kept byte-identical across the AIsa skills that need it —
+    financial/marketpulse/scripts/market_client.py is the canonical copy; change
+    it there first, then propagate.
     """
     key = os.environ.get("AISA_API_KEY", "").strip()
     if key:
@@ -76,8 +88,13 @@ def _resolve_aisa_api_key() -> str:
             if not sep or name.strip() != "AISA_API_KEY":
                 continue
             value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            if value[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = value.find(value[0], 1)
+                value = value[1:end] if end != -1 else value[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in value:
@@ -101,7 +118,8 @@ class MarketClient:
         self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
-                "AISA_API_KEY is required. Set it via environment variable or pass to constructor."
+                "AISA_API_KEY is required. Set the environment variable, add\n"
+                "AISA_API_KEY=<key> to ~/.aisa/credentials, or pass it to the constructor."
             )
 
     def _request(

--- a/financial/prediction-market-data/scripts/prediction_market_client.py
+++ b/financial/prediction-market-data/scripts/prediction_market_client.py
@@ -46,13 +46,74 @@ import urllib.error
 from typing import Any, Dict, List, Optional
 
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 class PredictionMarketClient:
     """Cross-Platform Prediction Market Data - AIsa API Client."""
 
     BASE_URL = "https://api.aisa.one/apis/v1"
 
     def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or os.environ.get("AISA_API_KEY")
+        self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
                 "AISA_API_KEY is required. Set it via environment variable or pass to constructor."

--- a/financial/prediction-market-data/scripts/prediction_market_client.py
+++ b/financial/prediction-market-data/scripts/prediction_market_client.py
@@ -628,7 +628,12 @@ Examples:
             print(output)
         except UnicodeEncodeError:
             print(json.dumps(result, indent=2, ensure_ascii=True))
-        sys.exit(0 if result.get("success", True) else 1)
+        # Endpoints returning a bare JSON array (polymarket markets, kalshi
+        # markets, ...) carry no "success" envelope, and .get() on a list
+        # raises AttributeError — the data printed fine but the process died
+        # with a traceback and exit 1. Only a dict can report failure.
+        failed = isinstance(result, dict) and not result.get("success", True)
+        sys.exit(1 if failed else 0)
 
 
 if __name__ == "__main__":

--- a/financial/prediction-market-data/scripts/prediction_market_client.py
+++ b/financial/prediction-market-data/scripts/prediction_market_client.py
@@ -49,17 +49,29 @@ from typing import Any, Dict, List, Optional
 def _resolve_aisa_api_key() -> str:
     """Resolve AISA_API_KEY from the environment, then from known credential files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY". `~/.aisa/credentials` is the
+    cross-harness convention AgentSpec already documents for exactly this case
+    (plugin-core/inject.ts: "scripts resolve these as: env var ->
+    ~/.aisa/credentials").
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env; the middle one covers harnesses that identify the profile by name
+    instead. Only the running profile is ever read, never a sibling's, so a host
+    with several profiles cannot hand back the wrong tenant's key.
+
     Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
+
+    Kept byte-identical across the AIsa skills that need it —
+    financial/marketpulse/scripts/market_client.py is the canonical copy; change
+    it there first, then propagate.
     """
     key = os.environ.get("AISA_API_KEY", "").strip()
     if key:
@@ -92,8 +104,13 @@ def _resolve_aisa_api_key() -> str:
             if not sep or name.strip() != "AISA_API_KEY":
                 continue
             value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            if value[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = value.find(value[0], 1)
+                value = value[1:end] if end != -1 else value[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in value:
@@ -116,7 +133,8 @@ class PredictionMarketClient:
         self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
-                "AISA_API_KEY is required. Set it via environment variable or pass to constructor."
+                "AISA_API_KEY is required. Set the environment variable, add\n"
+                "AISA_API_KEY=<key> to ~/.aisa/credentials, or pass it to the constructor."
             )
 
     def _request(

--- a/search-research/last30days/scripts/lib/env.py
+++ b/search-research/last30days/scripts/lib/env.py
@@ -289,7 +289,7 @@ def is_polymarket_available() -> bool:
 
     AISA is required for the hosted Polymarket integration.
     """
-    return bool(os.environ.get("AISA_API_KEY"))
+    return bool(get_config().get("AISA_API_KEY"))
 
 
 def is_tiktok_available(config: dict[str, Any]) -> bool:

--- a/search-research/last30days/scripts/lib/env.py
+++ b/search-research/last30days/scripts/lib/env.py
@@ -25,23 +25,37 @@ else:
 def _resolve_from_files(name: str) -> str:
     """Resolve a setting from the environment, then from known AIsa config files.
 
-    Hermes scrubs almost every environment variable before it spawns a skill
-    subprocess — anything whose name contains "KEY"/"TOKEN"/... outright, and
-    everything else that does not match a short safe-prefix allowlist (PATH,
-    HOME, LC_, XDG_, ...). AISA_API_KEY and AISA_MODEL are both dropped. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY"/"TOKEN"/... `~/.aisa/credentials`
+    is the cross-harness convention AgentSpec documents for exactly this case.
+
+    Applies to the model pins as much as the key: without a pin,
+    providers._resolve_model_pins raises and the run dies, and the only
+    documented recovery (`last30days setup`) is interactive.
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's settings into
-    another. Returns "" when nothing is found; never raises on an unreadable or
-    undecodable file.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env. Only the running profile is ever read, never a sibling's.
+
+    Returns "" when nothing is found, when clean mode is active
+    (LAST30DAYS_CONFIG_DIR=""), or when a file is unreadable — never raises.
     """
     value = os.environ.get(name, "").strip()
     if value:
         return value
+
+    # LAST30DAYS_CONFIG_DIR="" is clean mode: the caller has built a deliberately
+    # minimal environment and expects nothing to be picked up off disk.
+    # evaluate_search_quality's create_eval_env() relies on that to compare two
+    # revisions hermetically — reading the operator's model pin from
+    # ~/.aisa/credentials there would silently change what is being measured.
+    if CONFIG_FILE is None:
+        return ""
 
     home = os.path.expanduser("~")
     hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
@@ -70,8 +84,13 @@ def _resolve_from_files(name: str) -> str:
             if not sep or key.strip() != name:
                 continue
             val = val.strip()
-            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-                val = val[1:-1]
+            if val[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = val.find(val[0], 1)
+                val = val[1:end] if end != -1 else val[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in val:

--- a/search-research/last30days/scripts/lib/env.py
+++ b/search-research/last30days/scripts/lib/env.py
@@ -22,24 +22,26 @@ else:
     CONFIG_DIR = Path.home() / ".config" / "last30days"
     CONFIG_FILE = CONFIG_DIR / ".env"
 
-def _resolve_aisa_api_key() -> str:
-    """Resolve AISA_API_KEY from the environment, then from known credential files.
+def _resolve_from_files(name: str) -> str:
+    """Resolve a setting from the environment, then from known AIsa config files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    Hermes scrubs almost every environment variable before it spawns a skill
+    subprocess — anything whose name contains "KEY"/"TOKEN"/... outright, and
+    everything else that does not match a short safe-prefix allowlist (PATH,
+    HOME, LC_, XDG_, ...). AISA_API_KEY and AISA_MODEL are both dropped. It does
     pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
 
     Order: env -> ~/.aisa/credentials
            -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
 
     Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
-    Returns "" when nothing is found; never raises on an unreadable or
+    machine hosting several profiles cannot leak one profile's settings into
+    another. Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
     """
-    key = os.environ.get("AISA_API_KEY", "").strip()
-    if key:
-        return key
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
 
     home = os.path.expanduser("~")
     hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
@@ -64,23 +66,28 @@ def _resolve_aisa_api_key() -> str:
                 continue
             if line.startswith("export "):
                 line = line[len("export "):].lstrip()
-            name, sep, value = line.partition("=")
-            if not sep or name.strip() != "AISA_API_KEY":
+            key, sep, val = line.partition("=")
+            if not sep or key.strip() != name:
                 continue
-            value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            val = val.strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                val = val[1:-1]
             else:
                 for marker in (" #", "\t#"):
-                    if marker in value:
-                        value = value.split(marker, 1)[0]
-                value = value.strip()
+                    if marker in val:
+                        val = val.split(marker, 1)[0]
+                val = val.strip()
             # U+FFFD only appears where bytes failed to decode, so the value is
-            # corrupt and cannot be a real key — keep looking rather than send
-            # garbage as a bearer token.
-            if value and "�" not in value:
-                return value
+            # corrupt and cannot be a real setting — keep looking rather than
+            # send garbage as a bearer token or a model id.
+            if val and "�" not in val:
+                return val
     return ""
+
+
+def _resolve_aisa_api_key() -> str:
+    """Back-compat alias — lib/http.py imports this name."""
+    return _resolve_from_files("AISA_API_KEY")
 
 
 def _check_file_permissions(path: Path) -> None:
@@ -160,7 +167,7 @@ def get_config() -> dict[str, Any]:
     # Build config: process.env > project .env > global .env
     config = {
         'AISA_API_KEY': (os.environ.get('AISA_API_KEY') or merged_env.get('AISA_API_KEY')
-                         or _resolve_aisa_api_key() or None),
+                         or _resolve_from_files('AISA_API_KEY') or None),
         'AISA_BASE_URL': os.environ.get('AISA_BASE_URL') or merged_env.get('AISA_BASE_URL', 'https://api.aisa.one'),
         'GITHUB_TOKEN': (
             os.environ.get('GITHUB_TOKEN')
@@ -184,8 +191,21 @@ def get_config() -> dict[str, Any]:
         ('LAST30DAYS_REDDIT_COMMENTS', None),
     ]
 
+    # Settings that also fall back to the AIsa config files. Under a harness
+    # that scrubs the environment (hermes), os.environ is empty for all of
+    # these, and the model pins are as load-bearing as the key: without one,
+    # providers._resolve_model_pins raises and the whole run dies.
+    FILE_BACKED = {
+        'AISA_MODEL',
+        'LAST30DAYS_PLANNER_MODEL',
+        'LAST30DAYS_RERANK_MODEL',
+        'LAST30DAYS_FUN_MODEL',
+    }
     for key, default in keys:
-        config[key] = os.environ.get(key) or merged_env.get(key, default)
+        value = os.environ.get(key) or merged_env.get(key)
+        if not value and key in FILE_BACKED:
+            value = _resolve_from_files(key)
+        config[key] = value or default
 
     # Track which config source was used
     if project_env_path:

--- a/search-research/last30days/scripts/lib/env.py
+++ b/search-research/last30days/scripts/lib/env.py
@@ -22,6 +22,67 @@ else:
     CONFIG_DIR = Path.home() / ".config" / "last30days"
     CONFIG_FILE = CONFIG_DIR / ".env"
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 def _check_file_permissions(path: Path) -> None:
     """Warn to stderr if a secrets file has overly permissive permissions."""
     try:
@@ -98,7 +159,8 @@ def get_config() -> dict[str, Any]:
 
     # Build config: process.env > project .env > global .env
     config = {
-        'AISA_API_KEY': os.environ.get('AISA_API_KEY') or merged_env.get('AISA_API_KEY'),
+        'AISA_API_KEY': (os.environ.get('AISA_API_KEY') or merged_env.get('AISA_API_KEY')
+                         or _resolve_aisa_api_key() or None),
         'AISA_BASE_URL': os.environ.get('AISA_BASE_URL') or merged_env.get('AISA_BASE_URL', 'https://api.aisa.one'),
         'GITHUB_TOKEN': (
             os.environ.get('GITHUB_TOKEN')

--- a/search-research/last30days/scripts/lib/http.py
+++ b/search-research/last30days/scripts/lib/http.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 from . import __version__
 from . import log as _log
+from .env import _resolve_aisa_api_key
 
 DEFAULT_TIMEOUT = 30
 
@@ -219,7 +220,7 @@ def _inject_aisa_headers(url: str, headers: Dict[str, str], has_json_body: bool)
         return
     api_key = (
         headers.get("Authorization", "").removeprefix("Bearer ").strip()
-        or os.environ.get("AISA_API_KEY", "").strip()
+        or _resolve_aisa_api_key()
     )
     if not api_key:
         raise HTTPError("AISA_API_KEY is required for requests to api.aisa.one")

--- a/search-research/last30days/scripts/lib/youtube_yt.py
+++ b/search-research/last30days/scripts/lib/youtube_yt.py
@@ -31,8 +31,7 @@ TRANSCRIPT_LIMITS = {
 # Max words to keep from each transcript
 TRANSCRIPT_MAX_WORDS = 5000
 
-from . import aisa
-from . import env, http, log
+from . import aisa, env, http, log
 from .relevance import token_overlap_relevance as _compute_relevance
 
 
@@ -207,8 +206,9 @@ def search_youtube(
         Dict with 'items' list of video metadata dicts.
     """
     del to_date
-    # Not os.environ: hermes scrubs AISA_API_KEY from skill subprocesses, and
-    # returning "not configured" here silently drops YouTube from the run.
+    # Not os.environ: a harness that scrubs the environment (or a plugin
+    # install with no profile .env) leaves this empty, and returning
+    # "not configured" here silently drops YouTube from the whole run.
     api_key = env.get_config().get("AISA_API_KEY") or ""
     if not api_key:
         return {"items": [], "error": "AISA_API_KEY not configured"}

--- a/search-research/last30days/scripts/lib/youtube_yt.py
+++ b/search-research/last30days/scripts/lib/youtube_yt.py
@@ -31,7 +31,8 @@ TRANSCRIPT_LIMITS = {
 # Max words to keep from each transcript
 TRANSCRIPT_MAX_WORDS = 5000
 
-from . import aisa, http, log
+from . import aisa
+from . import env, http, log
 from .relevance import token_overlap_relevance as _compute_relevance
 
 
@@ -206,7 +207,9 @@ def search_youtube(
         Dict with 'items' list of video metadata dicts.
     """
     del to_date
-    api_key = os.environ.get("AISA_API_KEY", "")
+    # Not os.environ: hermes scrubs AISA_API_KEY from skill subprocesses, and
+    # returning "not configured" here silently drops YouTube from the run.
+    api_key = env.get_config().get("AISA_API_KEY") or ""
     if not api_key:
         return {"items": [], "error": "AISA_API_KEY not configured"}
     core_topic = _extract_core_subject(topic)

--- a/search-research/last30days/scripts/run-briefing.sh
+++ b/search-research/last30days/scripts/run-briefing.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYTHON="$("$ROOT/scripts/dev-python.sh")"
+PYTHON="$(bash "$ROOT/scripts/dev-python.sh")"
 
 cd "$ROOT"
 exec "$PYTHON" "$ROOT/scripts/briefing.py" "$@"

--- a/search-research/last30days/scripts/run-evaluate.sh
+++ b/search-research/last30days/scripts/run-evaluate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYTHON="$("$ROOT/scripts/dev-python.sh")"
+PYTHON="$(bash "$ROOT/scripts/dev-python.sh")"
 
 cd "$ROOT"
 exec "$PYTHON" "$ROOT/scripts/evaluate_search_quality.py" "$@"

--- a/search-research/last30days/scripts/run-last30days.sh
+++ b/search-research/last30days/scripts/run-last30days.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYTHON="$("$ROOT/scripts/dev-python.sh")"
+PYTHON="$(bash "$ROOT/scripts/dev-python.sh")"
 
 cd "$ROOT"
 exec "$PYTHON" "$ROOT/scripts/last30days.py" "$@"

--- a/search-research/last30days/scripts/run-tests.sh
+++ b/search-research/last30days/scripts/run-tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYTHON="$("$ROOT/scripts/dev-python.sh")"
+PYTHON="$(bash "$ROOT/scripts/dev-python.sh")"
 
 cd "$ROOT"
 exec "$PYTHON" -m pytest --capture=no "$@"

--- a/search-research/last30days/scripts/run-watchlist.sh
+++ b/search-research/last30days/scripts/run-watchlist.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYTHON="$("$ROOT/scripts/dev-python.sh")"
+PYTHON="$(bash "$ROOT/scripts/dev-python.sh")"
 
 cd "$ROOT"
 exec "$PYTHON" "$ROOT/scripts/watchlist.py" "$@"

--- a/search-research/last30days/scripts/sync.sh
+++ b/search-research/last30days/scripts/sync.sh
@@ -10,7 +10,7 @@ fi
 
 SRC="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET="$1"
-PYTHON="$("$SRC/scripts/dev-python.sh")"
+PYTHON="$(bash "$SRC/scripts/dev-python.sh")"
 
 mkdir -p "$TARGET/scripts/lib"
 cp "$SRC/SKILL.md" "$TARGET/SKILL.md"

--- a/search-research/multi-source-search/scripts/search_client.py
+++ b/search-research/multi-source-search/scripts/search_client.py
@@ -27,13 +27,74 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 class SearchClient:
     """AIsa Search API client."""
 
     BASE_URL = "https://api.aisa.one/apis/v1"
 
     def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or os.environ.get("AISA_API_KEY")
+        self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
                 "AISA_API_KEY is required. Set it via environment variable or pass to constructor."

--- a/search-research/multi-source-search/scripts/search_client.py
+++ b/search-research/multi-source-search/scripts/search_client.py
@@ -30,17 +30,29 @@ from typing import Any, Dict, List, Optional
 def _resolve_aisa_api_key() -> str:
     """Resolve AISA_API_KEY from the environment, then from known credential files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY". `~/.aisa/credentials` is the
+    cross-harness convention AgentSpec already documents for exactly this case
+    (plugin-core/inject.ts: "scripts resolve these as: env var ->
+    ~/.aisa/credentials").
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env; the middle one covers harnesses that identify the profile by name
+    instead. Only the running profile is ever read, never a sibling's, so a host
+    with several profiles cannot hand back the wrong tenant's key.
+
     Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
+
+    Kept byte-identical across the AIsa skills that need it —
+    financial/marketpulse/scripts/market_client.py is the canonical copy; change
+    it there first, then propagate.
     """
     key = os.environ.get("AISA_API_KEY", "").strip()
     if key:
@@ -73,8 +85,13 @@ def _resolve_aisa_api_key() -> str:
             if not sep or name.strip() != "AISA_API_KEY":
                 continue
             value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            if value[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = value.find(value[0], 1)
+                value = value[1:end] if end != -1 else value[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in value:
@@ -97,7 +114,8 @@ class SearchClient:
         self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
-                "AISA_API_KEY is required. Set it via environment variable or pass to constructor."
+                "AISA_API_KEY is required. Set the environment variable, add\n"
+                "AISA_API_KEY=<key> to ~/.aisa/credentials, or pass it to the constructor."
             )
 
     def _request(

--- a/social-media/aisa-twitter-api/scripts/twitter_client.py
+++ b/social-media/aisa-twitter-api/scripts/twitter_client.py
@@ -29,6 +29,67 @@ TWITTER_URL_WEIGHT = 23
 URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
 
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 class TwitterClient:
     """OpenClaw Twitter - Twitter/X API Client."""
 
@@ -36,7 +97,7 @@ class TwitterClient:
 
     def __init__(self, api_key: Optional[str] = None):
         """Initialize the client with an API key."""
-        self.api_key = api_key or os.environ.get("AISA_API_KEY")
+        self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
                 "AISA_API_KEY is required. Set it via environment variable."

--- a/social-media/aisa-twitter-api/scripts/twitter_client.py
+++ b/social-media/aisa-twitter-api/scripts/twitter_client.py
@@ -32,17 +32,29 @@ URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
 def _resolve_aisa_api_key() -> str:
     """Resolve AISA_API_KEY from the environment, then from known credential files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY". `~/.aisa/credentials` is the
+    cross-harness convention AgentSpec already documents for exactly this case
+    (plugin-core/inject.ts: "scripts resolve these as: env var ->
+    ~/.aisa/credentials").
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env; the middle one covers harnesses that identify the profile by name
+    instead. Only the running profile is ever read, never a sibling's, so a host
+    with several profiles cannot hand back the wrong tenant's key.
+
     Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
+
+    Kept byte-identical across the AIsa skills that need it —
+    financial/marketpulse/scripts/market_client.py is the canonical copy; change
+    it there first, then propagate.
     """
     key = os.environ.get("AISA_API_KEY", "").strip()
     if key:
@@ -75,8 +87,13 @@ def _resolve_aisa_api_key() -> str:
             if not sep or name.strip() != "AISA_API_KEY":
                 continue
             value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            if value[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = value.find(value[0], 1)
+                value = value[1:end] if end != -1 else value[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in value:
@@ -100,7 +117,8 @@ class TwitterClient:
         self.api_key = api_key or _resolve_aisa_api_key()
         if not self.api_key:
             raise ValueError(
-                "AISA_API_KEY is required. Set it via environment variable."
+                "AISA_API_KEY is required. Set the environment variable or add\n"
+                "AISA_API_KEY=<key> to ~/.aisa/credentials."
             )
 
     def _request(

--- a/social-media/aisa-twitter-api/scripts/twitter_oauth_client.py
+++ b/social-media/aisa-twitter-api/scripts/twitter_oauth_client.py
@@ -42,17 +42,29 @@ class RelayConfigError(ValueError):
 def _resolve_aisa_api_key() -> str:
     """Resolve AISA_API_KEY from the environment, then from known credential files.
 
-    Hermes scrubs environment variables whose name contains "KEY" before it
-    spawns a skill subprocess, so os.environ alone is not enough there. It does
-    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+    os.environ is not always populated. The plugin / OpenClaw install form has no
+    profile .env to inherit from, and hermes' sandboxed code-execution path
+    strips variables whose name contains "KEY". `~/.aisa/credentials` is the
+    cross-harness convention AgentSpec already documents for exactly this case
+    (plugin-core/inject.ts: "scripts resolve these as: env var ->
+    ~/.aisa/credentials").
 
     Order: env -> ~/.aisa/credentials
-           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env (when HERMES_PROFILE is set)
+           -> $HERMES_HOME/.env
 
-    Only the *running* profile's file is read, never a sibling profile's, so a
-    machine hosting several profiles cannot leak one profile's key into another.
+    Under `hermes --profile X`, HERMES_HOME *is* the profile directory and
+    HERMES_PROFILE is unset, so the last candidate resolves to that profile's own
+    .env; the middle one covers harnesses that identify the profile by name
+    instead. Only the running profile is ever read, never a sibling's, so a host
+    with several profiles cannot hand back the wrong tenant's key.
+
     Returns "" when nothing is found; never raises on an unreadable or
     undecodable file.
+
+    Kept byte-identical across the AIsa skills that need it —
+    financial/marketpulse/scripts/market_client.py is the canonical copy; change
+    it there first, then propagate.
     """
     key = os.environ.get("AISA_API_KEY", "").strip()
     if key:
@@ -85,8 +97,13 @@ def _resolve_aisa_api_key() -> str:
             if not sep or name.strip() != "AISA_API_KEY":
                 continue
             value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                value = value[1:-1]
+            if value[:1] in ("'", '"'):
+                # A quoted value ends at its closing quote; whatever follows is
+                # a trailing comment, not part of the secret. Checking "starts
+                # and ends with a quote" instead would miss `KEY="v" # note`
+                # and hand back the value with its quotes still attached.
+                end = value.find(value[0], 1)
+                value = value[1:end] if end != -1 else value[1:]
             else:
                 for marker in (" #", "\t#"):
                     if marker in value:
@@ -120,7 +137,10 @@ def load_config(args: argparse.Namespace) -> Dict[str, Any]:
     timeout = DEFAULT_TIMEOUT
 
     if not aisa_api_key:
-        raise RelayConfigError("AISA_API_KEY is required.")
+        raise RelayConfigError(
+            "AISA_API_KEY is required. Set the environment variable or add\n"
+            "AISA_API_KEY=<key> to ~/.aisa/credentials."
+        )
 
     return {
         "base_url": base_url,

--- a/social-media/aisa-twitter-api/scripts/twitter_oauth_client.py
+++ b/social-media/aisa-twitter-api/scripts/twitter_oauth_client.py
@@ -39,6 +39,67 @@ class RelayConfigError(ValueError):
     """Configuration is incomplete or invalid."""
 
 
+def _resolve_aisa_api_key() -> str:
+    """Resolve AISA_API_KEY from the environment, then from known credential files.
+
+    Hermes scrubs environment variables whose name contains "KEY" before it
+    spawns a skill subprocess, so os.environ alone is not enough there. It does
+    pass HERMES_HOME / HERMES_PROFILE through, which locates the active profile.
+
+    Order: env -> ~/.aisa/credentials
+           -> $HERMES_HOME/profiles/$HERMES_PROFILE/.env -> $HERMES_HOME/.env
+
+    Only the *running* profile's file is read, never a sibling profile's, so a
+    machine hosting several profiles cannot leak one profile's key into another.
+    Returns "" when nothing is found; never raises on an unreadable or
+    undecodable file.
+    """
+    key = os.environ.get("AISA_API_KEY", "").strip()
+    if key:
+        return key
+
+    home = os.path.expanduser("~")
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(home, ".hermes")
+
+    candidates = [os.path.join(home, ".aisa", "credentials")]
+    profile = os.environ.get("HERMES_PROFILE", "").strip()
+    if profile:
+        candidates.append(os.path.join(hermes_home, "profiles", profile, ".env"))
+    candidates.append(os.path.join(hermes_home, ".env"))
+
+    for path in candidates:
+        try:
+            # utf-8-sig drops a BOM; errors="replace" keeps a mis-encoded file
+            # from raising UnicodeDecodeError (a ValueError, not an OSError).
+            with open(path, encoding="utf-8-sig", errors="replace") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            name, sep, value = line.partition("=")
+            if not sep or name.strip() != "AISA_API_KEY":
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            else:
+                for marker in (" #", "\t#"):
+                    if marker in value:
+                        value = value.split(marker, 1)[0]
+                value = value.strip()
+            # U+FFFD only appears where bytes failed to decode, so the value is
+            # corrupt and cannot be a real key — keep looking rather than send
+            # garbage as a bearer token.
+            if value and "�" not in value:
+                return value
+    return ""
+
+
 def get_env(name: str, default: Optional[str] = None) -> Optional[str]:
     return os.environ.get(name, default)
 
@@ -55,7 +116,7 @@ def normalize_base_url(base_url: str) -> str:
 
 def load_config(args: argparse.Namespace) -> Dict[str, Any]:
     base_url = normalize_base_url(DEFAULT_BASE_URL)
-    aisa_api_key = get_env("AISA_API_KEY")
+    aisa_api_key = _resolve_aisa_api_key()
     timeout = DEFAULT_TIMEOUT
 
     if not aisa_api_key:


### PR DESCRIPTION
Five skills that the AIsa CIO agent consumes could not read their API key under
Hermes, and four other defects surfaced while proving that end to end.

## Why os.environ is not enough

The AIsa platform already documents the contract these skills were meant to
honour (`agent-spec/src/adapters/plugin-core/inject.ts`):

> scripts resolve these as: env var → `~/.aisa/credentials`

They never implemented it. Three situations where that bites:

- **plugin / OpenClaw installs** have no profile `.env` to inherit from, so the
  file is the only channel that reaches the script;
- hermes' **sandboxed code-execution path** (`tools/code_execution_tool.py`)
  strips variables whose name contains `KEY`/`TOKEN`/…;
- a user who has only ever put the key in `~/.aisa/credentials` — the documented
  place — gets a hard failure.

An earlier revision of this description claimed hermes strips `AISA_API_KEY`
before spawning *any* skill subprocess. That is wrong: skill commands run through
`tools/terminal_tool.py`, which does not scrub. Verified by probing a live
session — see the PR discussion.

## What changed

An identical `_resolve_aisa_api_key()` in each of the five skills, resolving:

1. `AISA_API_KEY`
2. `~/.aisa/credentials`
3. `$HERMES_HOME/profiles/$HERMES_PROFILE/.env`
4. `$HERMES_HOME/.env`

Only the running profile's file is read — never a sibling's — so a host with
several profiles cannot leak one profile's key into another or hand back the
wrong tenant's credential.

Parsing handles `export` prefixes, quoted values, inline `#` comments outside
quotes, whitespace around `=`, CRLF, and a UTF-8 BOM. It never raises: an
unreadable file is skipped, and a mis-decoded one is rejected rather than
returned as a garbage bearer token.

No new dependencies — stdlib only, Python 3.11 compatible.

## Four defects found while verifying

| Commit | Defect |
|---|---|
| `de65b53` | **last30days** invoked `$ROOT/scripts/dev-python.sh` by path, needing mode 100755. Channels that ship a skill as file content rather than a git checkout do not preserve that bit, and the skill died on `Permission denied` before running any Python. 6 call sites now go through `bash`. |
| `257336f` | **prediction-market-data** crashed on every array-returning endpoint: `sys.exit(0 if result.get("success", True) else 1)` raises `AttributeError` on a list. `polymarket markets` printed 83 KB of correct JSON and then exited 1 with a traceback — which any agent harness reads as a failed tool call. |
| `ce923c6` | **last30days** model pins have the same env problem as the key, one layer up. Losing the key is a clean error; losing the pins kills the run — `providers._resolve_model_pins` raises, and the only documented recovery (`last30days setup`) is interactive and therefore unavailable to an agent. The resolver is now generic and the four pins route through it. |
| `fb1f62b` | **last30days** `lib/youtube_yt.py` read `os.environ["AISA_API_KEY"]` directly and returned `{"items": [], "error": "AISA_API_KEY not configured"}`. Under a scrubbing harness that is always, so YouTube silently vanished from every run: exit 0, a normal-looking report, one source quietly missing. `is_polymarket_available()` had the same bug. |

## Verification

- A 177-case resolution contract suite across all seven touched files, covering
  precedence, quoting, `export`, comments, CRLF, BOM, non-UTF-8 and UTF-16 files,
  unreadable paths, empty values, and the sibling-profile isolation rule.
- A behavioural check that last30days' HTTP layer actually reaches the
  `Authorization` header, not merely that it can import the resolver.
- Live calls for all five skills with the environment scrubbed, against a real
  Hermes profile install: every skill returns real data with the key and model
  coming only from `~/.aisa/credentials`. last30days produces a full report
  (exit 0, ~8 KB, all eight sources probed).
- `.github/scripts/catalog_quality.py --changed-from origin/main` passes, as do
  the 15 quality-gate unit tests.

## Scope

Five skills only — the ones the AIsa CIO agent consumes. Other catalogue clients
(`web-search`, `tavily-*`, `aisa-twitter-post-engage`, …) still read `os.environ`
alone and will hit the same wall in a plugin install. Left for a follow-up rather
than widened here; the contract tests make propagating it mechanical.
