### PR TITLE
Add geo-visibility, b2b-lead-search, competitive-seo & social-listening skills

### DIFF
--- a/.github/scripts/catalog_quality.py
+++ b/.github/scripts/catalog_quality.py
@@ -21,6 +21,7 @@ CATEGORY_NAMES = (
     "ai-models",
     "creative",
     "financial",
+    "geo",
     "marketing",
     "search-research",
     "social-media",

--- a/.github/scripts/prepare-category-repo.sh
+++ b/.github/scripts/prepare-category-repo.sh
@@ -9,7 +9,7 @@ category="${1:-}"
 shift || true
 
 case "$category" in
-  financial|search-research|social-media|ai-models|marketing|creative) ;;
+  financial|search-research|social-media|ai-models|marketing|creative|geo) ;;
   *)
     usage
     echo "Unknown skill category: $category" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ self-contained skill:
 - `search-research/` — web, academic, Tavily, Perplexity, recent research
 - `social-media/` — Twitter/X and YouTube workflows
 - `ai-models/` — provider setup and LLM routing
-- `marketing/` — SEO and creator discovery
+- `marketing/` — SEO, B2B lead generation, and creator discovery
 - `creative/` — image and video generation
+- `geo/` — generative-engine-optimization / AI-search visibility
 
 Skills are consumed by any [agentskills.io](https://agentskills.io)-
 compatible harness (Claude Code, Claude, OpenCode, Cursor, Codex,

--- a/geo/LICENSE
+++ b/geo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AIsa (aisa.one)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/geo/README.md
+++ b/geo/README.md
@@ -1,0 +1,13 @@
+# GEO Skills
+
+Generative Engine Optimization (GEO / AEO) and AI-search visibility workflows.
+
+This category contains 1 self-contained Agent Skill.
+
+| Skill | Description |
+|---|---|
+| [geo-visibility](./geo-visibility/) | Check how a brand, product, or topic appears in real AI answer engines — ChatGPT, Gemini, Perplexity, Google AI Overviews, and Google AI Mode — via AIsa Oxylabs AI Search. Returns the AI-generated answer text plus the exact source URLs each engine cites, and can report whether your brand is mentioned and who else is cited. |
+
+## Repository
+
+Browse the [complete AIsa Agent Skills catalog](https://github.com/AIsa-team/agent-skills).

--- a/geo/geo-visibility/README.md
+++ b/geo/geo-visibility/README.md
@@ -1,0 +1,57 @@
+# GEO Visibility 🛰️
+
+Check how a brand, product, or topic appears across real AI answer engines —
+**ChatGPT, Gemini, Perplexity, Google AI Overviews, and Google AI Mode** — and
+see exactly which source URLs each engine cites. This is the "AI-era SEO"
+(GEO / AEO) capability: as users move from blue links to AI answers, you need
+to know whether *you* are in the answer and who is being cited.
+
+Powered by [AIsa](https://aisa.one) via the Oxylabs AI Search endpoint.
+
+## Compatibility
+
+Works with any [agentskills.io](https://agentskills.io)-compatible harness:
+**Claude Code**, **Claude**, **OpenAI Codex**, **Cursor**, **Gemini CLI**,
+**OpenCode**, **Goose**, **OpenClaw**, **Hermes**, and others.
+
+Requires Python 3 and `AISA_API_KEY` (get one at [aisa.one](https://aisa.one)).
+
+## Quick Start
+
+```bash
+export AISA_API_KEY="your-key"
+
+# What does Google's AI Overview say, and who does it cite? (fast, ~4-8s)
+python3 scripts/geo_client.py ask --source google_search \
+  --query "leading AI safety research companies"
+
+# Is my brand mentioned / cited in the answer?
+python3 scripts/geo_client.py brand --brand "Anthropic" \
+  --query "leading AI safety research companies"
+```
+
+## Sources
+
+| `--source`        | Engine                          | Typical latency |
+|-------------------|---------------------------------|-----------------|
+| `google_search`   | Google AI Overviews             | 4-8s            |
+| `google_ai_mode`  | Google AI Mode                  | 4-8s            |
+| `chatgpt`         | ChatGPT (web-connected)         | 40-60s          |
+| `gemini`          | Gemini                          | 40-60s          |
+| `perplexity`      | Perplexity                      | 40-60s          |
+
+## Use Cases
+
+- **GEO / AEO audit** — track your AI-answer share of voice over time.
+- **Competitor citation tracking** — see which competitor domains AI engines trust.
+- **Content gap analysis** — the cited URLs show what content is winning the answer.
+- **Market variation** — pass `--geo "United Kingdom"` etc. to compare regions.
+
+## Requirements
+
+- Python 3
+- `AISA_API_KEY` — required, get one at [aisa.one](https://aisa.one)
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/geo/geo-visibility/SKILL.md
+++ b/geo/geo-visibility/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: geo-visibility
+description: 'Check how a brand, product, or topic appears in real AI answer engines — ChatGPT, Gemini, Perplexity, Google AI Overviews, and Google AI Mode — via AIsa Oxylabs AI Search. Returns the AI-generated answer text plus the exact source URLs each engine cites, and can report whether your brand is mentioned and who else is cited. Use for GEO / AEO (Generative Engine Optimization), AI-search visibility audits, and competitor citation tracking.'
+license: MIT
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3 and AISA_API_KEY. AI sources (chatgpt/gemini/perplexity) can take 40-60s per call; Google sources are 4-8s.
+metadata:
+  aisa:
+    emoji: 🛰️
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
+---
+
+# GEO Visibility 🛰️
+
+**See whether AI answer engines mention and cite your brand — the "AI-era SEO" (GEO) capability. Powered by AIsa.**
+
+Traditional SEO tracks Google's blue links. But users increasingly get answers from ChatGPT, Gemini, Perplexity, and Google's AI Overviews — where only a handful of sources get cited. This skill sends a **real query** to those engines and returns the AI answer plus the URLs it cites, so you can audit whether your brand shows up and who is winning the citation.
+
+## Setup
+
+This skill requires the `AISA_API_KEY` environment variable (get one at [aisa.one](https://aisa.one)):
+
+```bash
+export AISA_API_KEY="your-aisa-api-key"
+```
+
+Never print, log, or commit the key.
+
+## Usage
+
+```bash
+# Ask one AI engine and see its answer + cited sources
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/geo-visibility/scripts/geo_client.py ask \
+  --source google_search --query "best CRM for startups"
+
+# Check whether a brand is mentioned / cited in an engine's answer
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/geo-visibility/scripts/geo_client.py brand \
+  --brand "Anthropic" --query "leading AI safety research companies"
+```
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `ask` | Query one AI engine and print its answer + all cited sources |
+| `brand` | Query an engine and report whether the brand is mentioned / cited, plus the full citation list (competitor visibility) |
+
+### Arguments
+
+| Argument | Applies to | Required | Default | Description |
+|----------|-----------|----------|---------|-------------|
+| `--query` / `-q` | both | Yes | — | The question a user might ask an AI engine |
+| `--brand` / `-b` | `brand` | Yes | — | Brand or product name to look for in the answer/citations |
+| `--source` / `-s` | both | No | `google_search` | One of `google_search`, `google_ai_mode`, `chatgpt`, `gemini`, `perplexity` |
+| `--geo` | both | No | `United States` | Country-level geo location |
+
+**Sources:** `google_search` = Google AI Overviews, `google_ai_mode` = Google AI Mode. `chatgpt`, `gemini`, and `perplexity` query those AI answer engines directly.
+
+> **Latency:** `chatgpt` / `gemini` / `perplexity` take ~40-60s per call; Google sources return in ~4-8s. Prefer Google sources for fast iteration.
+
+### Examples
+
+```bash
+# Google AI Overviews (fast): who does Google cite for a topic?
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/geo-visibility/scripts/geo_client.py ask \
+  -s google_search -q "best project management software 2026"
+
+# ChatGPT: does Notion appear when users ask about note-taking apps?
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/geo-visibility/scripts/geo_client.py brand \
+  -b "Notion" -q "best note taking apps" -s chatgpt
+
+# Perplexity in a specific market
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/geo-visibility/scripts/geo_client.py ask \
+  -s perplexity -q "top fintech companies" --geo "United Kingdom"
+```
+
+## Output
+
+- **ask** — the AI answer text (up to ~4000 chars) and a numbered list of every cited source URL with its display name.
+- **brand** — a visibility scorecard (`Mentioned in AI answer`, `Cited as a source`, count of your links), your own citations, the full competitor citation list, then the full answer.
+
+## When to Use
+
+Use this skill when the user asks about **AI search visibility**, **GEO / AEO**, whether their (or a competitor's) brand shows up in **ChatGPT / Gemini / Perplexity / Google AI Overviews**, or who gets **cited** for a topic. This is the differentiated "AI-era SEO" audit — for classic blue-link rankings use `competitive-seo` instead.
+
+## API Reference
+
+- [Oxylabs AI Search](https://aisa.one/docs/api-reference) — single passthrough endpoint (`POST /apis/v1/oxylabs/ai-search`) covering all five AI answer engines.
+
+See the [full AIsa API Reference](https://aisa.one/docs/api-reference) for the complete catalog.
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/geo/geo-visibility/scripts/geo_client.py
+++ b/geo/geo-visibility/scripts/geo_client.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+AIsa GEO Visibility — Python CLI Client
+=======================================
+
+Query real AI answer engines (ChatGPT, Gemini, Perplexity, Google AI
+Overviews, Google AI Mode) via the AIsa Oxylabs AI Search endpoint and
+inspect the generated answer text plus the source URLs each engine cites.
+
+This powers "GEO / AEO" (Generative Engine Optimization) workflows: check
+whether a brand, product, or topic shows up in AI answers and who gets cited.
+
+Requires the AISA_API_KEY environment variable.
+
+Usage:
+    python3 geo_client.py ask   --source google_search --query "best CRM for startups"
+    python3 geo_client.py ask   --source chatgpt --query "What is Anthropic known for?"
+    python3 geo_client.py brand --brand "Anthropic" --query "leading AI safety companies"
+    python3 geo_client.py brand --brand "Notion" --query "best note taking apps" --source gemini
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+AISA_BASE = "https://api.aisa.one/apis/v1"
+AI_SEARCH_PATH = "/oxylabs/ai-search"
+
+SOURCES = ["google_search", "google_ai_mode", "chatgpt", "gemini", "perplexity"]
+# Sources that take `prompt`; the rest take `query`.
+PROMPT_SOURCES = {"chatgpt", "gemini", "perplexity"}
+
+
+def get_api_key() -> str:
+    key = os.environ.get("AISA_API_KEY", "")
+    if not key:
+        print("Error: AISA_API_KEY environment variable is not set.", file=sys.stderr)
+        print("Get your key at https://aisa.one", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def aisa_post(api_key: str, path: str, body: dict[str, Any], timeout: int = 120) -> dict[str, Any]:
+    url = f"{AISA_BASE}{path}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"API error {e.code} on {path}: {body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error on {path}: {e.reason}", file=sys.stderr)
+        print("AI sources (chatgpt/gemini/perplexity) can take 40-60s; try again.", file=sys.stderr)
+        sys.exit(1)
+
+
+def build_body(source: str, query: str, geo: str) -> dict[str, Any]:
+    body: dict[str, Any] = {"source": source, "parse": True}
+    if geo:
+        body["geo_location"] = geo
+    if source in PROMPT_SOURCES:
+        body["prompt"] = query
+        if source == "chatgpt":
+            body["search"] = True
+    else:
+        body["query"] = query
+        body["render"] = "html"
+    return body
+
+
+def _first_result_content(data: dict[str, Any]) -> dict[str, Any]:
+    results = data.get("results")
+    if isinstance(results, list) and results:
+        content = results[0].get("content")
+        if isinstance(content, dict):
+            return content
+    return {}
+
+
+def parse_answer(source: str, data: dict[str, Any]) -> tuple[str, list[dict[str, str]]]:
+    """Return (answer_text, [{source, url}, ...]) normalized across engines."""
+    answer_parts: list[str] = []
+    citations: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    def add_cite(name: str, url: str) -> None:
+        url = (url or "").strip()
+        if url and url not in seen:
+            seen.add(url)
+            citations.append({"source": (name or "").strip(), "url": url})
+
+    content = _first_result_content(data)
+
+    # chatgpt / gemini -> response_text + citations[]
+    if source in ("chatgpt", "gemini"):
+        txt = content.get("response_text") or content.get("text") or ""
+        if isinstance(txt, list):
+            txt = "\n".join(str(t) for t in txt)
+        if txt:
+            answer_parts.append(str(txt))
+        for c in content.get("citations", []) or []:
+            if isinstance(c, dict):
+                add_cite(c.get("title") or c.get("source") or "", c.get("url") or c.get("link") or "")
+            elif isinstance(c, str):
+                add_cite("", c)
+
+    # perplexity -> answer + top_sources/sources_results
+    elif source == "perplexity":
+        txt = content.get("response_text") or content.get("answer") or content.get("text") or ""
+        if txt:
+            answer_parts.append(str(txt))
+        for key in ("top_sources", "sources_results", "sources", "citations"):
+            for c in content.get(key, []) or []:
+                if isinstance(c, dict):
+                    add_cite(c.get("title") or c.get("source") or "", c.get("url") or c.get("link") or "")
+                elif isinstance(c, str):
+                    add_cite("", c)
+
+    # google_search / google_ai_mode -> nested content.results
+    else:
+        res = content.get("results")
+        res = res if isinstance(res, dict) else content
+        # Google AI Overviews
+        for ov in (res.get("ai_overviews") or []):
+            for block in ov.get("answer_text", []) or []:
+                for frag in block.get("fragments", []) or []:
+                    if frag.get("text"):
+                        answer_parts.append(frag["text"])
+                    for ref in frag.get("references", []) or []:
+                        add_cite(ref.get("source", ""), ref.get("url", ""))
+            for bl in ov.get("bullet_list", []) or []:
+                for pt in bl.get("points", []) or []:
+                    if pt.get("text"):
+                        answer_parts.append("- " + pt["text"])
+                    for ref in pt.get("references", []) or []:
+                        add_cite(ref.get("source", ""), ref.get("url", ""))
+            for ref in ov.get("references", []) or []:
+                add_cite(ref.get("source", ""), ref.get("url", ""))
+        # Google AI Mode -> content.citations[]{text, urls[]}
+        for c in (content.get("citations") or res.get("citations") or []):
+            if isinstance(c, dict):
+                if c.get("text"):
+                    answer_parts.append(str(c["text"]))
+                for u in c.get("urls", []) or []:
+                    add_cite("", u)
+
+    return "\n".join(p for p in answer_parts if p).strip(), citations
+
+
+def print_answer(source: str, query: str, answer: str, citations: list[dict[str, str]]) -> None:
+    print(f"\n{'='*66}")
+    print(f"  AI Engine: {source}")
+    print(f"  Query:     {query}")
+    print(f"{'='*66}\n")
+    if answer:
+        print("Answer:\n")
+        print(answer[:4000])
+    else:
+        print("(No AI answer returned for this query/engine — the engine may not")
+        print(" have shown an AI answer for this term.)")
+    print(f"\nCited sources ({len(citations)}):")
+    if citations:
+        for i, c in enumerate(citations, 1):
+            label = f" — {c['source']}" if c.get("source") else ""
+            print(f"  [{i}] {c['url']}{label}")
+    else:
+        print("  (none)")
+    print()
+
+
+def cmd_ask(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body = build_body(args.source, args.query, args.geo)
+    data = aisa_post(api_key, AI_SEARCH_PATH, body)
+    answer, citations = parse_answer(args.source, data)
+    print_answer(args.source, args.query, answer, citations)
+
+
+def cmd_brand(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body = build_body(args.source, args.query, args.geo)
+    data = aisa_post(api_key, AI_SEARCH_PATH, body)
+    answer, citations = parse_answer(args.source, data)
+
+    brand = args.brand
+    brand_l = brand.lower()
+    mentioned = brand_l in answer.lower()
+    cited_rows = [c for c in citations if brand_l in c["url"].lower() or brand_l in (c.get("source", "").lower())]
+
+    print(f"\n{'='*66}")
+    print(f"  GEO Visibility Check")
+    print(f"{'='*66}")
+    print(f"  Brand:   {brand}")
+    print(f"  Query:   {args.query}")
+    print(f"  Engine:  {args.source}")
+    print(f"{'='*66}\n")
+    print(f"  Mentioned in AI answer:   {'YES' if mentioned else 'NO'}")
+    print(f"  Cited as a source:        {'YES' if cited_rows else 'NO'} ({len(cited_rows)} link(s))")
+    print(f"  Total sources cited:      {len(citations)}")
+    if cited_rows:
+        print("\n  Your citations:")
+        for c in cited_rows:
+            print(f"    - {c['url']}")
+    print("\n  All cited sources (competitor visibility):")
+    for i, c in enumerate(citations[:20], 1):
+        label = f" — {c['source']}" if c.get("source") else ""
+        print(f"    [{i}] {c['url']}{label}")
+    print_answer(args.source, args.query, answer, citations)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AIsa GEO Visibility — query AI answer engines and inspect citations",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_ask = sub.add_parser("ask", help="Query one AI engine and show its answer + citations")
+    p_ask.add_argument("--query", "-q", required=True, help="Question / search term")
+    p_ask.add_argument("--source", "-s", default="google_search", choices=SOURCES)
+    p_ask.add_argument("--geo", default="United States", help="Country-level geo (e.g. 'United States')")
+    p_ask.set_defaults(func=cmd_ask)
+
+    p_brand = sub.add_parser("brand", help="Check if a brand appears/is cited in an AI answer")
+    p_brand.add_argument("--brand", "-b", required=True, help="Brand or product name to look for")
+    p_brand.add_argument("--query", "-q", required=True, help="Question a user might ask an AI engine")
+    p_brand.add_argument("--source", "-s", default="google_search", choices=SOURCES)
+    p_brand.add_argument("--geo", default="United States", help="Country-level geo")
+    p_brand.set_defaults(func=cmd_brand)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,11 +1,12 @@
 # Marketing Skills
 
-SEO research and creator/KOL discovery workflows.
+SEO research, B2B lead generation, and creator/KOL discovery workflows.
 
-This category contains 2 self-contained Agent Skills.
+This category contains 3 self-contained Agent Skills.
 
 | Skill | Description |
 |---|---|
+| [b2b-lead-search](./b2b-lead-search/) | Search and enrich B2B leads with Apollo via AIsa — find target-account companies by keyword, industry, size, and location; enrich a person to resolve their title, company, and work email; enrich a company by domain; and search saved Apollo contacts. Use for GTM prospecting, building target-account lists, finding decision-makers, and CRM data enrichment. |
 | [seo-keyword-research](./seo-keyword-research/) | Use this skill when a user asks for SEO keyword research, keyword discovery, search volume analysis, keyword difficulty, search intent mapping, topic clusters, content opportunities, competitor keyword gaps, or a keyword strategy for a domain, URL, product, market, or seed topic. When a website is provided, crawl and interpret the site first, then use AIsa API access to DataForSEO keyword, SERP, trend, Labs, and OnPage endpoints plus AIsa LLM reasoning to find non-brand keyword opportunities. |
 | [kol-creator-discovery](./kol-creator-discovery/) | Use this skill when a user needs KOL or influencer research, creator email lookup, similar-creator discovery, outreach-list building, influencer prospecting, or a contact table from TikTok, Instagram, or YouTube profile URLs. It uses AIsa's WaveInflu APIs to find verified creator emails, match similar YouTube or TikTok creators, enrich each recommended profile with contact emails, and return an outreach-ready Markdown table without inventing missing data. |
 

--- a/marketing/b2b-lead-search/README.md
+++ b/marketing/b2b-lead-search/README.md
@@ -1,0 +1,58 @@
+# B2B Lead Search 🎯
+
+Search and enrich B2B leads from Apollo's 270M+ contact/company database via
+[AIsa](https://aisa.one). Find target-account companies, surface
+decision-makers by title, and resolve a person's title, company, and email —
+the foundation of an automated GTM / cold-outreach flow.
+
+## Compatibility
+
+Works with any [agentskills.io](https://agentskills.io)-compatible harness:
+**Claude Code**, **Claude**, **OpenAI Codex**, **Cursor**, **Gemini CLI**,
+**OpenCode**, **Goose**, **OpenClaw**, **Hermes**, and others.
+
+Requires Python 3 and `AISA_API_KEY` (get one at [aisa.one](https://aisa.one)).
+
+## Quick Start
+
+```bash
+export AISA_API_KEY="your-key"
+
+# Target-account companies
+python3 scripts/apollo_client.py companies --keywords "fintech" \
+  --locations "United States" --employees "50,200" --per-page 5
+
+# Search your saved Apollo contacts by title
+python3 scripts/apollo_client.py contacts --titles "Head of Marketing" --per-page 5
+
+# Person enrichment -> title / company / email
+python3 scripts/apollo_client.py enrich-person --first-name Dylan \
+  --last-name Field --company Figma
+
+# Company enrichment
+python3 scripts/apollo_client.py enrich-org --domain stripe.com
+```
+
+## Use Cases
+
+- **Target-account list building** — filter the global company DB by keyword, size, and geography.
+- **Decision-maker enrichment** — resolve a person's title, company, LinkedIn, and work email.
+- **CRM enrichment** — fill in missing title / company / email / firmographic fields.
+- **GTM automation** — feed results into an outreach sequence (e.g. AgentMail).
+
+> `contacts` searches your own saved Apollo contacts, not the global 270M-person
+> database. Build lists via `companies` + `enrich-person`.
+
+## Data handling
+
+Contact data is sensitive. Do not publish emails or transmit lists to other
+systems without authorization, and never invent an email the API did not return.
+
+## Requirements
+
+- Python 3
+- `AISA_API_KEY` — required, get one at [aisa.one](https://aisa.one)
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/marketing/b2b-lead-search/SKILL.md
+++ b/marketing/b2b-lead-search/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: b2b-lead-search
+description: 'Search and enrich B2B leads with Apollo via AIsa — find target-account companies by keyword, industry, size, and location; enrich a person to resolve their title, company, and work email; enrich a company by domain; and search your saved Apollo contacts. Use for GTM prospecting, building target-account lists, finding decision-makers, and CRM data enrichment.'
+license: MIT
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3 and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 🎯
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
+---
+
+# B2B Lead Search 🎯
+
+**Prospect and enrich B2B leads from Apollo's 270M+ contact/company database. Powered by AIsa.**
+
+Find the right companies, surface the right decision-makers, and resolve a person's title, company, and work email — the foundation of an automated GTM / cold-outreach workflow.
+
+## Setup
+
+This skill requires the `AISA_API_KEY` environment variable (get one at [aisa.one](https://aisa.one)):
+
+```bash
+export AISA_API_KEY="your-aisa-api-key"
+```
+
+Never print, log, or commit the key. Treat returned contact data (names, emails) as sensitive — do not publish or transmit it elsewhere without authorization.
+
+## Usage
+
+```bash
+# Find target-account companies
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/b2b-lead-search/scripts/apollo_client.py companies \
+  --keywords "artificial intelligence" --per-page 5
+
+# Enrich a person -> title, company, email
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/b2b-lead-search/scripts/apollo_client.py enrich-person \
+  --first-name Dylan --last-name Field --company Figma
+```
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `companies` | Search Apollo's global company database by keyword, location, employee range |
+| `enrich-person` | Resolve one person's title, company, LinkedIn, and work email |
+| `enrich-org` | Enrich a company by domain or name (industry, size, founded, description) |
+| `contacts` | Search **your own saved Apollo contacts** by title/location/company (not the global people database) |
+
+### Arguments
+
+| Argument | Subcommand | Description |
+|----------|-----------|-------------|
+| `--keywords` / `-k` | `companies`, `contacts` | Comma-separated company keywords |
+| `--locations` / `-l` | `companies`, `contacts` | Comma-separated locations |
+| `--employees` | `companies` | Employee-count range as `min,max` (e.g. `50,200`) |
+| `--titles` / `-t` | `contacts` | Comma-separated job titles |
+| `--per-page` | `companies`, `contacts` | Results per page (default 10) |
+| `--page` | `companies`, `contacts` | Page number (default 1) |
+| `--first-name`, `--last-name`, `--company`, `--domain`, `--email` | `enrich-person` | Any subset that identifies the person |
+| `--domain`, `--name` | `enrich-org` | Company domain or name |
+
+### Examples
+
+```bash
+# US AI companies with 50-200 employees
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/b2b-lead-search/scripts/apollo_client.py companies \
+  -k "artificial intelligence" -l "United States" --employees "50,200" --per-page 10
+
+# Marketing decision-makers
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/b2b-lead-search/scripts/apollo_client.py contacts \
+  -t "Head of Marketing,VP Marketing" --per-page 10
+
+# Enrich a company by domain
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/b2b-lead-search/scripts/apollo_client.py enrich-org \
+  --domain stripe.com
+```
+
+> **Note on `contacts`:** Apollo's `contacts/search` operates on the API
+> account's *own saved contacts*, not the global 270M-person database. To build
+> a decision-maker list from scratch, use `companies` to find target accounts,
+> then `enrich-person` (with a name + company/domain) to resolve each person's
+> title and work email.
+
+## Output
+
+Human-readable lists: companies (name, domain, industry, employees, location, LinkedIn), contacts (name, title, company, email, LinkedIn), and enrichment cards (full resolved profile / company facts). `companies`/`contacts` also print the total match count and page info.
+
+## When to Use
+
+Use for **B2B prospecting, GTM lead lists, finding decision-makers, and CRM enrichment**. Pair with the `kol-creator-discovery` skill for influencer outreach, or `competitive-seo` / `geo-visibility` for the marketing-intelligence half of a GTM workflow. Do not fabricate emails — only report what the API returns.
+
+## API Reference
+
+This skill calls these AIsa Apollo endpoints:
+
+- `POST /apis/v1/apollo/mixed_companies/search` — company / account search
+- `POST /apis/v1/apollo/contacts/search` — contact search
+- `POST /apis/v1/apollo/people/match` — person enrichment
+- `POST /apis/v1/apollo/organizations/enrich` — organization enrichment
+
+See the [full AIsa API Reference](https://aisa.one/docs/api-reference) for the complete catalog.
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/marketing/b2b-lead-search/scripts/apollo_client.py
+++ b/marketing/b2b-lead-search/scripts/apollo_client.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+AIsa B2B Lead Search — Python CLI Client
+========================================
+
+Search Apollo's B2B database (270M+ contacts / companies) and enrich people
+and organizations via the AIsa Apollo relay. Build target-account lists,
+find decision-makers, and resolve a person's title, company, and email.
+
+Requires the AISA_API_KEY environment variable.
+
+Usage:
+    python3 apollo_client.py companies --keywords "artificial intelligence" --per-page 5
+    python3 apollo_client.py companies --keywords "fintech" --employees "50,200" --locations "United States"
+    python3 apollo_client.py contacts  --titles "Head of Marketing,VP Marketing" --per-page 5
+    python3 apollo_client.py enrich-person --first-name Dylan --last-name Field --company Figma
+    python3 apollo_client.py enrich-org --domain stripe.com
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+AISA_BASE = "https://api.aisa.one/apis/v1"
+
+
+def get_api_key() -> str:
+    key = os.environ.get("AISA_API_KEY", "")
+    if not key:
+        print("Error: AISA_API_KEY environment variable is not set.", file=sys.stderr)
+        print("Get your key at https://aisa.one", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def aisa_post(api_key: str, path: str, body: dict[str, Any]) -> dict[str, Any]:
+    url = f"{AISA_BASE}{path}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"API error {e.code} on {path}: {body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error on {path}: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def cmd_companies(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body: dict[str, Any] = {"per_page": args.per_page, "page": args.page}
+    if args.keywords:
+        body["q_organization_keyword_tags"] = _csv(args.keywords)
+    if args.locations:
+        body["organization_locations"] = _csv(args.locations)
+    if args.employees:
+        # Format: "min,max" -> Apollo range string "min,max"
+        body["organization_num_employees_ranges"] = [args.employees.replace(" ", "")]
+    data = aisa_post(api_key, "/apollo/mixed_companies/search", body)
+
+    orgs = data.get("organizations") or data.get("accounts") or []
+    pg = data.get("pagination", {})
+    print(f"\n{'='*66}")
+    print(f"  Company Search — {pg.get('total_entries', '?')} matches "
+          f"(page {pg.get('page', '?')}/{pg.get('total_pages', '?')})")
+    print(f"{'='*66}\n")
+    for i, o in enumerate(orgs, 1):
+        print(f"  [{i}] {o.get('name', 'Unknown')}")
+        if o.get("primary_domain") or o.get("website_url"):
+            print(f"      Domain:    {o.get('primary_domain') or o.get('website_url')}")
+        if o.get("industry"):
+            print(f"      Industry:  {o.get('industry')}")
+        emp = o.get("estimated_num_employees")
+        if emp:
+            print(f"      Employees: {emp}")
+        loc = ", ".join(x for x in [o.get("city"), o.get("state"), o.get("country")] if x)
+        if loc:
+            print(f"      Location:  {loc}")
+        if o.get("linkedin_url"):
+            print(f"      LinkedIn:  {o.get('linkedin_url')}")
+        print()
+
+
+def cmd_contacts(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body: dict[str, Any] = {"per_page": args.per_page, "page": args.page}
+    if args.titles:
+        body["person_titles"] = _csv(args.titles)
+    if args.locations:
+        body["person_locations"] = _csv(args.locations)
+    if args.keywords:
+        body["q_organization_keyword_tags"] = _csv(args.keywords)
+    data = aisa_post(api_key, "/apollo/contacts/search", body)
+
+    people = data.get("contacts") or data.get("people") or []
+    pg = data.get("pagination", {})
+    print(f"\n{'='*66}")
+    print(f"  Contact Search — {pg.get('total_entries', '?')} matches "
+          f"(page {pg.get('page', '?')}/{pg.get('total_pages', '?')})")
+    print(f"{'='*66}\n")
+    for i, p in enumerate(people, 1):
+        print(f"  [{i}] {p.get('name') or '(No name)'}")
+        if p.get("title"):
+            print(f"      Title:     {p.get('title')}")
+        org = p.get("organization") or {}
+        if org.get("name") or p.get("organization_name"):
+            print(f"      Company:   {org.get('name') or p.get('organization_name')}")
+        if p.get("email"):
+            print(f"      Email:     {p.get('email')}")
+        if p.get("linkedin_url"):
+            print(f"      LinkedIn:  {p.get('linkedin_url')}")
+        print()
+
+
+def cmd_enrich_person(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body: dict[str, Any] = {}
+    if args.first_name:
+        body["first_name"] = args.first_name
+    if args.last_name:
+        body["last_name"] = args.last_name
+    if args.company:
+        body["organization_name"] = args.company
+    if args.domain:
+        body["domain"] = args.domain
+    if args.email:
+        body["email"] = args.email
+    data = aisa_post(api_key, "/apollo/people/match", body)
+
+    p = data.get("person") or {}
+    print(f"\n{'='*66}")
+    print(f"  Person Enrichment")
+    print(f"{'='*66}\n")
+    if not p:
+        print("  No match found.")
+        return
+    print(f"  Name:      {p.get('name')}")
+    print(f"  Title:     {p.get('title')}")
+    print(f"  Email:     {p.get('email') or '(not revealed)'}")
+    print(f"  LinkedIn:  {p.get('linkedin_url')}")
+    org = p.get("organization") or {}
+    if org:
+        print(f"  Company:   {org.get('name')} ({org.get('website_url', '')})")
+    loc = ", ".join(x for x in [p.get("city"), p.get("state"), p.get("country")] if x)
+    if loc:
+        print(f"  Location:  {loc}")
+    print()
+
+
+def cmd_enrich_org(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body: dict[str, Any] = {}
+    if args.domain:
+        body["domain"] = args.domain
+    if args.name:
+        body["organization_name"] = args.name
+    data = aisa_post(api_key, "/apollo/organizations/enrich", body)
+
+    o = data.get("organization") or {}
+    print(f"\n{'='*66}")
+    print(f"  Organization Enrichment")
+    print(f"{'='*66}\n")
+    if not o:
+        print("  No match found.")
+        return
+    print(f"  Name:        {o.get('name')}")
+    print(f"  Domain:      {o.get('primary_domain') or o.get('website_url')}")
+    print(f"  Industry:    {o.get('industry')}")
+    print(f"  Employees:   {o.get('estimated_num_employees')}")
+    print(f"  Founded:     {o.get('founded_year')}")
+    print(f"  LinkedIn:    {o.get('linkedin_url')}")
+    if o.get("short_description"):
+        print(f"\n  About: {o['short_description'][:400]}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AIsa B2B Lead Search (Apollo)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_co = sub.add_parser("companies", help="Search companies / target accounts")
+    p_co.add_argument("--keywords", "-k", help="Comma-separated company keywords")
+    p_co.add_argument("--locations", "-l", help="Comma-separated HQ locations")
+    p_co.add_argument("--employees", help="Employee count range 'min,max' (e.g. '50,200')")
+    p_co.add_argument("--per-page", type=int, default=10)
+    p_co.add_argument("--page", type=int, default=1)
+    p_co.set_defaults(func=cmd_companies)
+
+    p_ct = sub.add_parser("contacts", help="Search saved contacts by title / company")
+    p_ct.add_argument("--titles", "-t", help="Comma-separated job titles")
+    p_ct.add_argument("--locations", "-l", help="Comma-separated person locations")
+    p_ct.add_argument("--keywords", "-k", help="Comma-separated company keywords")
+    p_ct.add_argument("--per-page", type=int, default=10)
+    p_ct.add_argument("--page", type=int, default=1)
+    p_ct.set_defaults(func=cmd_contacts)
+
+    p_ep = sub.add_parser("enrich-person", help="Resolve a person's title/company/email")
+    p_ep.add_argument("--first-name")
+    p_ep.add_argument("--last-name")
+    p_ep.add_argument("--company", help="Organization name")
+    p_ep.add_argument("--domain", help="Company domain")
+    p_ep.add_argument("--email")
+    p_ep.set_defaults(func=cmd_enrich_person)
+
+    p_eo = sub.add_parser("enrich-org", help="Enrich a company by domain or name")
+    p_eo.add_argument("--domain")
+    p_eo.add_argument("--name")
+    p_eo.set_defaults(func=cmd_enrich_org)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/search-research/README.md
+++ b/search-research/README.md
@@ -2,10 +2,11 @@
 
 Web, academic, Tavily, Perplexity, and recent multi-source research workflows.
 
-This category contains 12 self-contained Agent Skills.
+This category contains 13 self-contained Agent Skills.
 
 | Skill | Description |
 |---|---|
+| [competitive-seo](./competitive-seo/) | Live Google SERP rankings, keyword ideas, and search-volume/CPC/competition data via AIsa DataForSEO. See who ranks for a term (organic results + SERP features), expand a seed keyword into ranked ideas with volume, and pull ad economics for a keyword list. Use for SEO audits, competitor rank tracking, keyword research, content-gap analysis, and PPC planning. |
 | [multi-source-search](./multi-source-search/) | Multi-source intelligent search for agents. Retrieval across web, scholar, Tavily, and Perplexity Sonar models. |
 | [multi-search](./multi-search/) | Parallel multi-source search combining Web, Scholar, Smart, and Tavily results with confidence scoring and AI synthesis. Best for comprehensive research requiring cross-source validation. Use when: the user needs web search, research, source discovery, or content extraction. |
 | [smart-search](./smart-search/) | Intelligent hybrid search combining web and academic sources via AIsa Smart Search endpoint. Best when you need both web and scholarly results. Use when: the user needs web search, research, source discovery, or content extraction. |

--- a/search-research/competitive-seo/README.md
+++ b/search-research/competitive-seo/README.md
@@ -1,0 +1,48 @@
+# Competitive SEO 📈
+
+Live Google SERP rankings, keyword ideas, and search-volume / CPC / competition
+data via [AIsa](https://aisa.one) (DataForSEO). See who ranks for a term today,
+expand a seed keyword into ranked ideas, and pull the ad economics of any
+keyword list.
+
+## Compatibility
+
+Works with any [agentskills.io](https://agentskills.io)-compatible harness:
+**Claude Code**, **Claude**, **OpenAI Codex**, **Cursor**, **Gemini CLI**,
+**OpenCode**, **Goose**, **OpenClaw**, **Hermes**, and others.
+
+Requires Python 3 and `AISA_API_KEY` (get one at [aisa.one](https://aisa.one)).
+
+## Quick Start
+
+```bash
+export AISA_API_KEY="your-key"
+
+# Live Google SERP
+python3 scripts/dataforseo_client.py serp --keyword "ai agents" --depth 10
+
+# Keyword ideas with volume/CPC
+python3 scripts/dataforseo_client.py keywords --seed "ai agents" --limit 15
+
+# Volume / CPC / competition for a keyword list
+python3 scripts/dataforseo_client.py volume --keywords "ai agents,llm,rag pipeline"
+```
+
+## Use Cases
+
+- **Rank tracking** — see the live top-N organic results for any keyword/market.
+- **Keyword research** — expand a seed topic into a ranked idea list with volume.
+- **Content-gap analysis** — the SERP shows which domains own a term.
+- **PPC planning** — CPC + competition tell you what a keyword costs to buy.
+
+For AI-answer-engine visibility (ChatGPT / Gemini / Perplexity / Google AI
+Overviews), use the sibling **geo-visibility** skill.
+
+## Requirements
+
+- Python 3
+- `AISA_API_KEY` — required, get one at [aisa.one](https://aisa.one)
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/search-research/competitive-seo/SKILL.md
+++ b/search-research/competitive-seo/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: competitive-seo
+description: 'Live Google SERP rankings, keyword ideas, and search-volume/CPC/competition data via AIsa DataForSEO. See who ranks for a term (organic results + SERP features), expand a seed keyword into ranked ideas with volume, and pull ad economics for a keyword list. Use for SEO audits, competitor rank tracking, keyword research, content-gap analysis, and PPC planning.'
+license: MIT
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3 and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 📈
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
+---
+
+# Competitive SEO 📈
+
+**Live Google rankings, keyword ideas, and search economics. Powered by AIsa (DataForSEO).**
+
+See exactly who ranks for a term today, discover the keywords worth targeting with real search volume, and pull CPC + competition so you know what a keyword is worth.
+
+## Setup
+
+This skill requires the `AISA_API_KEY` environment variable (get one at [aisa.one](https://aisa.one)):
+
+```bash
+export AISA_API_KEY="your-aisa-api-key"
+```
+
+Never print, log, or commit the key.
+
+## Usage
+
+```bash
+# Live Google SERP for a keyword (organic results + SERP features)
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/competitive-seo/scripts/dataforseo_client.py serp \
+  --keyword "ai agents" --depth 10
+
+# Expand a seed into ranked keyword ideas with volume/CPC
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/competitive-seo/scripts/dataforseo_client.py keywords \
+  --seed "ai agents" --limit 15
+
+# Search volume / CPC / competition for a specific keyword list
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/competitive-seo/scripts/dataforseo_client.py volume \
+  --keywords "ai agents,llm,rag pipeline"
+```
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `serp` | Live Google organic SERP (rank, title, URL, domain, snippet) + SERP features |
+| `keywords` | Keyword ideas expanded from a seed, with volume / CPC / competition |
+| `volume` | Search volume / CPC / competition for an explicit keyword list |
+
+### Arguments
+
+| Argument | Subcommand | Default | Description |
+|----------|-----------|---------|-------------|
+| `--keyword` / `-k` | `serp` | — | The query to fetch the SERP for |
+| `--depth` / `-d` | `serp` | 10 | Number of organic results |
+| `--seed` / `-s` | `keywords` | — | Seed keyword to expand |
+| `--limit` / `-n` | `keywords` | 15 | Number of keyword ideas |
+| `--keywords` / `-k` | `volume` | — | Comma-separated keyword list |
+| `--location` | all | `United States` | DataForSEO location name |
+| `--language` | all | `English` | DataForSEO language name |
+
+### Examples
+
+```bash
+# Who ranks for a competitor term in the UK?
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/competitive-seo/scripts/dataforseo_client.py serp \
+  -k "project management software" --location "United Kingdom" -d 20
+
+# Build a keyword map around a topic
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/competitive-seo/scripts/dataforseo_client.py keywords \
+  -s "email marketing" -n 25
+```
+
+## Output
+
+- **serp** — numbered organic results (absolute rank, title, URL, domain, snippet) followed by the SERP features present (knowledge graph, videos, related searches, etc.).
+- **keywords** / **volume** — an aligned table of keyword, monthly search volume, CPC (USD), and competition index (0-1).
+
+## When to Use
+
+Use for **classic search-engine SEO**: rank tracking, keyword research, content-gap analysis, and PPC/CPC planning. For **AI-answer-engine** visibility (ChatGPT / Gemini / Perplexity / Google AI Overviews) use the `geo-visibility` skill instead.
+
+## API Reference
+
+This skill calls these AIsa DataForSEO endpoints:
+
+- `POST /apis/v1/dataforseo/serp/google/organic/live/advanced` — live Google organic SERP
+- `POST /apis/v1/dataforseo/dataforseo_labs/google/keyword_ideas/live` — keyword ideas from a seed
+- `POST /apis/v1/dataforseo/keywords_data/google_ads/search_volume/live` — search volume / CPC / competition
+
+See the [full AIsa API Reference](https://aisa.one/docs/api-reference) for the complete catalog.
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/search-research/competitive-seo/scripts/dataforseo_client.py
+++ b/search-research/competitive-seo/scripts/dataforseo_client.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+AIsa Competitive SEO — Python CLI Client
+========================================
+
+Live Google SERP rankings, keyword ideas, and search-volume/CPC data via the
+AIsa DataForSEO relay. Use it to see who ranks for a term, discover related
+keywords with volume, and pull ad economics (CPC + competition) for a list of
+keywords.
+
+Requires the AISA_API_KEY environment variable.
+
+Usage:
+    python3 dataforseo_client.py serp     --keyword "ai agents" --depth 10
+    python3 dataforseo_client.py keywords --seed "ai agents" --limit 15
+    python3 dataforseo_client.py volume   --keywords "ai agents,llm,rag pipeline"
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+AISA_BASE = "https://api.aisa.one/apis/v1"
+
+
+def get_api_key() -> str:
+    key = os.environ.get("AISA_API_KEY", "")
+    if not key:
+        print("Error: AISA_API_KEY environment variable is not set.", file=sys.stderr)
+        print("Get your key at https://aisa.one", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def aisa_post(api_key: str, path: str, body: Any) -> dict[str, Any]:
+    url = f"{AISA_BASE}{path}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=90) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"API error {e.code} on {path}: {body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error on {path}: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _task_result(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Unwrap DataForSEO's tasks[].result[].items[] envelope; check status."""
+    if data.get("status_code") not in (20000, None):
+        print(f"DataForSEO error {data.get('status_code')}: {data.get('status_message')}",
+              file=sys.stderr)
+    tasks = data.get("tasks") or []
+    if not tasks:
+        return []
+    t0 = tasks[0]
+    if t0.get("status_code") and t0["status_code"] != 20000:
+        print(f"Task error {t0['status_code']}: {t0.get('status_message')}", file=sys.stderr)
+    results = t0.get("result") or []
+    if not results:
+        return []
+    return results[0].get("items") or []
+
+
+def _fmt_num(n: Any) -> str:
+    if n is None:
+        return "—"
+    try:
+        return f"{int(n):,}"
+    except (ValueError, TypeError):
+        return str(n)
+
+
+def cmd_serp(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body = [{
+        "keyword": args.keyword,
+        "location_name": args.location,
+        "language_name": args.language,
+        "depth": args.depth,
+    }]
+    data = aisa_post(api_key, "/dataforseo/serp/google/organic/live/advanced", body)
+    items = _task_result(data)
+    organic = [i for i in items if i.get("type") == "organic"]
+
+    print(f"\n{'='*66}")
+    print(f"  Google SERP — \"{args.keyword}\" ({args.location})")
+    print(f"{'='*66}\n")
+    for it in organic[: args.depth]:
+        rank = it.get("rank_absolute") or it.get("rank_group")
+        print(f"  #{rank:<3} {it.get('title', '')}")
+        print(f"        {it.get('url', '')}")
+        print(f"        domain: {it.get('domain', '')}")
+        if it.get("description"):
+            print(f"        {it['description'][:140]}")
+        print()
+
+    features = sorted({i.get("type") for i in items if i.get("type") != "organic"})
+    if features:
+        print(f"  SERP features present: {', '.join(features)}\n")
+
+
+def cmd_keywords(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    body = [{
+        "keywords": [args.seed],
+        "location_name": args.location,
+        "language_name": args.language,
+        "limit": args.limit,
+    }]
+    data = aisa_post(api_key, "/dataforseo/dataforseo_labs/google/keyword_ideas/live", body)
+    items = _task_result(data)
+
+    print(f"\n{'='*66}")
+    print(f"  Keyword Ideas — seed \"{args.seed}\" ({args.location})")
+    print(f"{'='*66}\n")
+    print(f"  {'Keyword':<40} {'Volume':>10} {'CPC':>8} {'Comp':>6}")
+    print(f"  {'-'*40} {'-'*10} {'-'*8} {'-'*6}")
+    for it in items[: args.limit]:
+        ki = it.get("keyword_info") or {}
+        kw = (it.get("keyword") or "")[:40]
+        vol = _fmt_num(ki.get("search_volume"))
+        cpc = ki.get("cpc")
+        cpc_s = f"${cpc:.2f}" if isinstance(cpc, (int, float)) else "—"
+        comp = ki.get("competition")
+        comp_s = f"{comp:.2f}" if isinstance(comp, (int, float)) else "—"
+        print(f"  {kw:<40} {vol:>10} {cpc_s:>8} {comp_s:>6}")
+    print()
+
+
+def cmd_volume(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    keywords = [k.strip() for k in args.keywords.split(",") if k.strip()]
+    body = [{
+        "keywords": keywords,
+        "location_name": args.location,
+        "language_name": args.language,
+    }]
+    data = aisa_post(api_key, "/dataforseo/keywords_data/google_ads/search_volume/live", body)
+    items = _task_result(data)
+
+    print(f"\n{'='*66}")
+    print(f"  Search Volume & CPC ({args.location})")
+    print(f"{'='*66}\n")
+    print(f"  {'Keyword':<40} {'Volume':>10} {'CPC':>8} {'Comp':>6}")
+    print(f"  {'-'*40} {'-'*10} {'-'*8} {'-'*6}")
+    for it in items:
+        kw = (it.get("keyword") or "")[:40]
+        vol = _fmt_num(it.get("search_volume"))
+        cpc = it.get("cpc")
+        cpc_s = f"${cpc:.2f}" if isinstance(cpc, (int, float)) else "—"
+        comp = it.get("competition")
+        comp_s = f"{comp:.2f}" if isinstance(comp, (int, float)) else "—"
+        print(f"  {kw:<40} {vol:>10} {cpc_s:>8} {comp_s:>6}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AIsa Competitive SEO (DataForSEO)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_serp = sub.add_parser("serp", help="Live Google organic SERP for a keyword")
+    p_serp.add_argument("--keyword", "-k", required=True)
+    p_serp.add_argument("--depth", "-d", type=int, default=10, help="Number of results")
+    p_serp.add_argument("--location", default="United States")
+    p_serp.add_argument("--language", default="English")
+    p_serp.set_defaults(func=cmd_serp)
+
+    p_kw = sub.add_parser("keywords", help="Keyword ideas with volume/CPC from a seed")
+    p_kw.add_argument("--seed", "-s", required=True)
+    p_kw.add_argument("--limit", "-n", type=int, default=15)
+    p_kw.add_argument("--location", default="United States")
+    p_kw.add_argument("--language", default="English")
+    p_kw.set_defaults(func=cmd_keywords)
+
+    p_vol = sub.add_parser("volume", help="Search volume/CPC/competition for keywords")
+    p_vol.add_argument("--keywords", "-k", required=True, help="Comma-separated keywords")
+    p_vol.add_argument("--location", default="United States")
+    p_vol.add_argument("--language", default="English")
+    p_vol.set_defaults(func=cmd_volume)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/social-media/README.md
+++ b/social-media/README.md
@@ -1,11 +1,12 @@
 # Social Media Skills
 
-Twitter/X intelligence and engagement plus YouTube discovery and SERP research.
+Twitter/X intelligence and engagement, Reddit/Instagram/Pinterest social listening, plus YouTube discovery and SERP research.
 
-This category contains 9 self-contained Agent Skills.
+This category contains 10 self-contained Agent Skills.
 
 | Skill | Description |
 |---|---|
+| [social-listening](./social-listening/) | Monitor public social conversation across Reddit, Instagram, and Pinterest via AIsa Scrape Creators. Search Reddit for a topic, pull a subreddit's recent posts and community stats, read a public Instagram profile snapshot, and scan Pinterest pins for a theme. Use for social listening, brand/topic monitoring, audience research, and trend discovery. |
 | [twitter-autopilot](./twitter-autopilot/) | Searches and reads X (Twitter): profiles, timelines, mentions, followers, tweet search, trends, lists, communities, and Spaces. Publishes posts, likes/unlikes tweets, and follows/unfollows users after the user completes OAuth in the browser. Use when the user asks about Twitter/X data, social listening, posting, or interacting with tweets/users without sharing account passwords. |
 | [aisa-twitter-api](./aisa-twitter-api/) | Twitter/X research, monitoring, watchlists, and OAuth-approved posting through AIsa. Use when: the user needs one flagship Twitter skill for trend tracking, competitor monitoring, timeline analysis, or approved posting without sharing passwords. Supports search, watchlists, relay-based reads, and OAuth-gated text or media posting. |
 | [aisa-twitter-command-center](./aisa-twitter-command-center/) | Search X/Twitter profiles, tweets, trends, lists, communities, and Spaces through the AIsa relay, then support approved posting workflows with OAuth. Use when the user asks for Twitter research, monitoring, or posting without sharing passwords. |

--- a/social-media/social-listening/README.md
+++ b/social-media/social-listening/README.md
@@ -1,0 +1,50 @@
+# Social Listening 👂
+
+Monitor public social conversation across **Reddit, Instagram, and Pinterest**
+via [AIsa](https://aisa.one) (Scrape Creators). Search Reddit for a topic, size
+up a community, read an Instagram profile, or scan Pinterest for a theme.
+
+## Compatibility
+
+Works with any [agentskills.io](https://agentskills.io)-compatible harness:
+**Claude Code**, **Claude**, **OpenAI Codex**, **Cursor**, **Gemini CLI**,
+**OpenCode**, **Goose**, **OpenClaw**, **Hermes**, and others.
+
+Requires Python 3 and `AISA_API_KEY` (get one at [aisa.one](https://aisa.one)).
+
+## Quick Start
+
+```bash
+export AISA_API_KEY="your-key"
+
+# Reddit topic search
+python3 scripts/scrapecreators_client.py reddit-search --query "ai agents"
+
+# Subreddit recent posts + community stats
+python3 scripts/scrapecreators_client.py reddit-subreddit --subreddit artificial
+python3 scripts/scrapecreators_client.py subreddit-stats  --subreddit artificial
+
+# Instagram profile snapshot
+python3 scripts/scrapecreators_client.py instagram --handle nasa
+
+# Pinterest theme scan
+python3 scripts/scrapecreators_client.py pinterest --query "healthy recipes"
+```
+
+## Use Cases
+
+- **Brand / topic monitoring** — what is Reddit saying about a product this week.
+- **Audience research** — community size and activity before you invest in a channel.
+- **Trend discovery** — surface rising themes on Pinterest and Reddit.
+- **Account profiling** — quick public Instagram stats for a creator or competitor.
+
+Only public data is returned; respect each platform's terms and user privacy.
+
+## Requirements
+
+- Python 3
+- `AISA_API_KEY` — required, get one at [aisa.one](https://aisa.one)
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/social-media/social-listening/SKILL.md
+++ b/social-media/social-listening/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: social-listening
+description: 'Monitor public social conversation across Reddit, Instagram, and Pinterest via AIsa Scrape Creators. Search Reddit for a topic, pull a subreddit''s recent posts and community stats, read a public Instagram profile snapshot, and scan Pinterest pins for a theme. Use for social listening, brand/topic monitoring, audience research, and trend discovery.'
+license: MIT
+compatibility: Works with any agentskills.io-compatible harness — Claude Code, Claude, OpenCode, Cursor, Codex, Gemini CLI, OpenClaw, Hermes, Goose, and others. Requires Python 3 and AISA_API_KEY.
+metadata:
+  aisa:
+    emoji: 👂
+    homepage: https://aisa.one
+    requires:
+      bins:
+      - python3
+      env:
+      - AISA_API_KEY
+    primaryEnv: AISA_API_KEY
+    harnesses:
+    - claude-code
+    - claude
+    - opencode
+    - cursor
+    - codex
+    - gemini-cli
+    - openclaw
+    - hermes
+    - goose
+---
+
+# Social Listening 👂
+
+**Track what people are saying on Reddit, Instagram, and Pinterest. Powered by AIsa (Scrape Creators).**
+
+Search Reddit for a topic, size up a community, read an Instagram profile, or scan Pinterest for a theme — the raw signal for brand monitoring, audience research, and trend discovery.
+
+## Setup
+
+This skill requires the `AISA_API_KEY` environment variable (get one at [aisa.one](https://aisa.one)):
+
+```bash
+export AISA_API_KEY="your-aisa-api-key"
+```
+
+Never print, log, or commit the key.
+
+## Usage
+
+```bash
+# Search Reddit posts for a topic
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/social-listening/scripts/scrapecreators_client.py reddit-search \
+  --query "ai agents"
+
+# Public Instagram profile snapshot
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/social-listening/scripts/scrapecreators_client.py instagram \
+  --handle nasa
+```
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `reddit-search` | Search Reddit posts by keyword |
+| `reddit-subreddit` | Recent posts from a specific subreddit |
+| `subreddit-stats` | Community size / activity stats for a subreddit |
+| `instagram` | Public Instagram profile snapshot (followers, posts, bio) |
+| `pinterest` | Search Pinterest pins by theme |
+
+### Arguments
+
+| Argument | Subcommand | Default | Description |
+|----------|-----------|---------|-------------|
+| `--query` / `-q` | `reddit-search`, `pinterest` | — | Search term |
+| `--subreddit` / `-s` | `reddit-subreddit`, `subreddit-stats` | — | Subreddit name (no `r/`) |
+| `--handle` / `-u` | `instagram` | — | Instagram username (no `@`) |
+| `--sort` | `reddit-search`, `reddit-subreddit` | varies | Sort order |
+| `--timeframe` | `reddit-search`, `reddit-subreddit` | varies | Time window |
+| `--limit` / `-n` | most | 10 | Max items to print |
+
+### Examples
+
+```bash
+# Top posts about a brand this week
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/social-listening/scripts/scrapecreators_client.py reddit-search \
+  -q "notion ai" --sort top --timeframe week -n 15
+
+# How active is a community?
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/social-listening/scripts/scrapecreators_client.py subreddit-stats \
+  -s artificial
+
+# Pinterest theme scan
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/social-listening/scripts/scrapecreators_client.py pinterest \
+  -q "healthy meal prep" -n 15
+```
+
+## Output
+
+- **reddit-search / reddit-subreddit** — post title, subreddit, author, upvotes, comment count, a snippet, and the permalink.
+- **subreddit-stats** — subscribers, weekly active users, weekly posts, and description.
+- **instagram** — name, verified flag, followers, following, post count, category, bio, and link.
+- **pinterest** — pin title, description, pinner, and URL.
+
+## When to Use
+
+Use for **social listening / brand monitoring** on Reddit, Instagram, and Pinterest — tracking topics, sizing communities, and profiling accounts. For X/Twitter use the `twitter-*` skills; for YouTube use `youtube-serp`; for influencer email discovery use `kol-creator-discovery`. Only public data is returned; respect platform terms and privacy.
+
+## API Reference
+
+This skill calls these AIsa Scrape Creators endpoints:
+
+- `GET /apis/v1/reddit/search` — Reddit post search
+- `GET /apis/v1/reddit/subreddit` — subreddit recent posts
+- `GET /apis/v1/reddit/subreddit/details` — subreddit community stats
+- `GET /apis/v1/instagram/profile` — public Instagram profile
+- `GET /apis/v1/pinterest/search` — Pinterest pin search
+
+See the [full AIsa API Reference](https://aisa.one/docs/api-reference) for the complete catalog.
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repo root.

--- a/social-media/social-listening/scripts/scrapecreators_client.py
+++ b/social-media/social-listening/scripts/scrapecreators_client.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+AIsa Social Listening — Python CLI Client
+=========================================
+
+Monitor public social conversation across Reddit, Instagram, and Pinterest via
+the AIsa Scrape Creators relay. Search Reddit for a topic, pull a subreddit's
+recent posts and stats, read an Instagram profile, or scan Pinterest pins for
+a theme.
+
+Requires the AISA_API_KEY environment variable.
+
+Usage:
+    python3 scrapecreators_client.py reddit-search    --query "ai agents"
+    python3 scrapecreators_client.py reddit-subreddit --subreddit artificial
+    python3 scrapecreators_client.py subreddit-stats  --subreddit artificial
+    python3 scrapecreators_client.py instagram        --handle nasa
+    python3 scrapecreators_client.py pinterest        --query "healthy recipes"
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+AISA_BASE = "https://api.aisa.one/apis/v1"
+
+
+def get_api_key() -> str:
+    key = os.environ.get("AISA_API_KEY", "")
+    if not key:
+        print("Error: AISA_API_KEY environment variable is not set.", file=sys.stderr)
+        print("Get your key at https://aisa.one", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def aisa_get(api_key: str, path: str, params: dict[str, Any]) -> dict[str, Any]:
+    qs = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
+    url = f"{AISA_BASE}{path}?{qs}" if qs else f"{AISA_BASE}{path}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"API error {e.code} on {path}: {body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error on {path}: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _reddit_url(post: dict[str, Any]) -> str:
+    pl = post.get("permalink") or ""
+    if pl.startswith("http"):
+        return pl
+    if pl:
+        return f"https://www.reddit.com{pl}"
+    return post.get("url") or ""
+
+
+def _print_reddit_posts(posts: list[dict[str, Any]], limit: int) -> None:
+    for i, p in enumerate(posts[:limit], 1):
+        print(f"  [{i}] {p.get('title', '(no title)')}")
+        print(f"      r/{p.get('subreddit', '?')} · u/{p.get('author', '?')} · "
+              f"{p.get('ups', p.get('score', 0))} upvotes · {p.get('num_comments', 0)} comments")
+        body = (p.get("selftext") or "").strip().replace("\n", " ")
+        if body:
+            print(f"      {body[:160]}")
+        print(f"      {_reddit_url(p)}")
+        print()
+
+
+def cmd_reddit_search(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    data = aisa_get(api_key, "/reddit/search",
+                    {"query": args.query, "sort": args.sort, "timeframe": args.timeframe})
+    posts = data.get("posts") or []
+    print(f"\n{'='*66}")
+    print(f"  Reddit Search — \"{args.query}\"  ({len(posts)} posts)")
+    print(f"{'='*66}\n")
+    _print_reddit_posts(posts, args.limit)
+
+
+def cmd_reddit_subreddit(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    data = aisa_get(api_key, "/reddit/subreddit",
+                    {"subreddit": args.subreddit, "sort": args.sort, "timeframe": args.timeframe})
+    posts = data.get("posts") or []
+    print(f"\n{'='*66}")
+    print(f"  r/{args.subreddit} — recent posts ({len(posts)})")
+    print(f"{'='*66}\n")
+    _print_reddit_posts(posts, args.limit)
+
+
+def cmd_subreddit_stats(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    d = aisa_get(api_key, "/reddit/subreddit/details", {"subreddit": args.subreddit})
+    print(f"\n{'='*66}")
+    print(f"  r/{d.get('display_name', args.subreddit)} — community stats")
+    print(f"{'='*66}\n")
+    print(f"  Subscribers:        {d.get('subscribers') or d.get('num_subscribers') or '—'}")
+    print(f"  Weekly active:      {d.get('weekly_active_users', '—')}")
+    print(f"  Weekly posts:       {d.get('weekly_contributions', '—')}")
+    if d.get("public_description"):
+        print(f"\n  About: {d['public_description'][:300]}")
+    print()
+
+
+def cmd_instagram(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    data = aisa_get(api_key, "/instagram/profile", {"handle": args.handle})
+    u = (data.get("data") or {}).get("user") or {}
+    if not u:
+        print("No profile data returned.")
+        return
+    followers = (u.get("edge_followed_by") or {}).get("count")
+    following = (u.get("edge_follow") or {}).get("count")
+    posts = (u.get("edge_owner_to_timeline_media") or {}).get("count")
+    print(f"\n{'='*66}")
+    print(f"  Instagram — @{u.get('username', args.handle)}")
+    print(f"{'='*66}\n")
+    print(f"  Name:       {u.get('full_name', '—')}"
+          f"{'  (verified)' if u.get('is_verified') else ''}")
+    print(f"  Followers:  {followers if followers is not None else '—'}")
+    print(f"  Following:  {following if following is not None else '—'}")
+    print(f"  Posts:      {posts if posts is not None else '—'}")
+    if u.get("category_name") or u.get("business_category_name"):
+        print(f"  Category:   {u.get('category_name') or u.get('business_category_name')}")
+    bio = (u.get("biography") or "").strip()
+    if bio:
+        print(f"\n  Bio: {bio[:300]}")
+    ext = u.get("external_url")
+    if ext:
+        print(f"  Link: {ext}")
+    print()
+
+
+def cmd_pinterest(args: argparse.Namespace) -> None:
+    api_key = get_api_key()
+    data = aisa_get(api_key, "/pinterest/search", {"query": args.query})
+    pins = data.get("pins") or []
+    printable = [p for p in pins if isinstance(p.get("title"), str) and p.get("title")]
+    print(f"\n{'='*66}")
+    print(f"  Pinterest — \"{args.query}\"  ({len(printable)} pins with titles)")
+    print(f"{'='*66}\n")
+    for i, p in enumerate(printable[: args.limit], 1):
+        title = p.get("grid_title") or p.get("title") or "(untitled)"
+        print(f"  [{i}] {title}")
+        desc = (p.get("description") or "").strip().replace("\n", " ")
+        if desc:
+            print(f"      {desc[:140]}")
+        pinner = p.get("pinner") or {}
+        pinner_name = pinner.get("username") if isinstance(pinner, dict) else pinner
+        if pinner_name:
+            print(f"      by @{pinner_name}")
+        if p.get("url"):
+            print(f"      {p['url']}")
+        print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AIsa Social Listening (Scrape Creators)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_rs = sub.add_parser("reddit-search", help="Search Reddit posts by keyword")
+    p_rs.add_argument("--query", "-q", required=True)
+    p_rs.add_argument("--sort", default="relevance", choices=["relevance", "hot", "top", "new", "comments"])
+    p_rs.add_argument("--timeframe", default="all", choices=["hour", "day", "week", "month", "year", "all"])
+    p_rs.add_argument("--limit", "-n", type=int, default=10)
+    p_rs.set_defaults(func=cmd_reddit_search)
+
+    p_rr = sub.add_parser("reddit-subreddit", help="Recent posts from a subreddit")
+    p_rr.add_argument("--subreddit", "-s", required=True)
+    p_rr.add_argument("--sort", default="hot", choices=["hot", "top", "new", "rising"])
+    p_rr.add_argument("--timeframe", default="week", choices=["hour", "day", "week", "month", "year", "all"])
+    p_rr.add_argument("--limit", "-n", type=int, default=10)
+    p_rr.set_defaults(func=cmd_reddit_subreddit)
+
+    p_ss = sub.add_parser("subreddit-stats", help="Community size / activity stats")
+    p_ss.add_argument("--subreddit", "-s", required=True)
+    p_ss.set_defaults(func=cmd_subreddit_stats)
+
+    p_ig = sub.add_parser("instagram", help="Public Instagram profile snapshot")
+    p_ig.add_argument("--handle", "-u", required=True, help="Username without @")
+    p_ig.set_defaults(func=cmd_instagram)
+
+    p_pin = sub.add_parser("pinterest", help="Search Pinterest pins by theme")
+    p_pin.add_argument("--query", "-q", required=True)
+    p_pin.add_argument("--limit", "-n", type=int, default=10)
+    p_pin.set_defaults(func=cmd_pinterest)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Four new AIsa Agent Skills that expose previously-uncovered gateway capabilities. Each skill is a self-contained directory with a stdlib-only `python3` client (no pip deps), a `SKILL.md`, and a `README.md`, following the existing catalog conventions.

| Skill | Path | Provider / Endpoint(s) |
|---|---|---|
| **geo-visibility** 🛰️ | `geo/geo-visibility/` | Oxylabs AI Search — `POST /apis/v1/oxylabs/ai-search` (ChatGPT, Gemini, Perplexity, Google AI Overviews, Google AI Mode) |
| **b2b-lead-search** 🎯 | `marketing/b2b-lead-search/` | Apollo — `mixed_companies/search`, `people/match`, `organizations/enrich`, `contacts/search` |
| **competitive-seo** 📈 | `search-research/competitive-seo/` | DataForSEO — `serp/google/organic/live/advanced`, `dataforseo_labs/google/keyword_ideas/live`, `keywords_data/google_ads/search_volume/live` |
| **social-listening** 👂 | `social-media/social-listening/` | Scrape Creators — `reddit/search`, `reddit/subreddit`, `reddit/subreddit/details`, `instagram/profile`, `pinterest/search` |

**geo-visibility** is the flagship differentiator — the "AI-era SEO" (GEO / AEO) capability: query real AI answer engines and see whether a brand is mentioned and who gets cited.

## Verification

All four smoke-tested against `https://api.aisa.one` with a real test-tier key — HTTP 200 with parsed output:

- **geo-visibility** — `brand --brand Anthropic --query "leading AI safety research companies"` (google_search): mentioned=YES, cited=YES (anthropic.com/research), 17 total cited sources.
- **b2b-lead-search** — `companies -k "artificial intelligence"`: 269,725 matches (Google, Amazon, ...); `enrich-person` Dylan Field → CEO & Co-founder of Figma, dylan@figma.com.
- **competitive-seo** — `serp -k "ai agents"`: IBM #1, Google #3, AWS #4 + SERP features; `keywords` returns volume/CPC/competition.
- **social-listening** — `reddit-search`, `instagram --handle nasa` (104M followers, verified), `subreddit-stats`, `pinterest` all return live data.

## Notes

- Added a new top-level `geo/` category, registered in `.github/scripts/catalog_quality.py` and `prepare-category-repo.sh`, with its own `LICENSE` and `README.md`.
- Apollo global people search (`mixed_people/search`) is disabled on the gateway; `contacts` searches saved contacts only, so the skill routes decision-maker discovery through `companies` + `enrich-person` and documents this inline.
- Catalog quality gate passes (`46 skills`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
